### PR TITLE
docs: document remote server/client mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ codex exec --edit-mode trusted "update CHANGELOG and open a PR"
 ```
 
 Safety guidance:
+
 - Prefer running in a VM or container when using `--edit-mode trusted`.
 - Pair with `--sandbox workspace-write` for guardrails. If you need `--sandbox danger-full-access`, only do so inside an isolated environment.
 - You can control command timeouts via `-c command_timeout_ms=120000` or disable with `-c command_timeout_ms=\"none\"`.
@@ -73,6 +74,9 @@ You can also use Codex with an API key, but this requires [additional setup](./d
 
 Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp). Enable by adding an `mcp_servers` section to your `~/.codex/config.toml`.
 
+### Remote server/client mode
+
+Codex also includes a lightweight TCP server and client that let you run the agent on one machine and drive it from another. Launch the server with `cargo run -p codex-server` (or the `codex-server` binary) and connect using `cargo run -p codex-client` or the `codex-client` binary. The server boots the same `ConversationManager` used by the CLI, so plugins, MCP servers and other runtime features remain available when Codex runs in this remote mode.
 
 ### Configuration
 
@@ -110,4 +114,3 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -31,6 +31,10 @@ It is still experimental, but you can also launch Codex as an MCP _server_ by ru
 npx @modelcontextprotocol/inspector codex mcp
 ```
 
+### Remote server and client
+
+For remote workflows, the workspace includes `codex-server` and `codex-client` binaries. `codex-server` exposes a raw TCP interface that speaks the same JSON protocol used by the CLI, and `codex-client` forwards stdin to the server and prints events. Because the server spins up the full `ConversationManager`, all plugins, MCP servers, and other runtime features remain available when using Codex over the network.
+
 ### Notifications
 
 You can enable notifications by configuring a script that is run whenever the agent finishes a turn. The [notify documentation](../docs/config.md#notify) includes a detailed example that explains how to get desktop notifications via [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS.
@@ -135,6 +139,7 @@ codex --edit-mode trusted
 ```
 
 Safety guidance for `trusted`:
+
 - Prefer running in a VM or container.
 - Consider pairing with `--sandbox workspace-write` for guardrails. If you need `--sandbox danger-full-access`, only do so inside an isolated environment.
 - Control host command timeouts via `-c command_timeout_ms=120000` or disable with `-c command_timeout_ms=\"none\"`.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -41,4 +41,8 @@ env = { "API_KEY" = "value" }
 ```
 
 > [!TIP]
-> It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues. 
+> It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues.
+
+## Remote server and client
+
+Codex can also run as a minimal TCP server (`cargo run -p codex-server`) and be driven by a matching client (`cargo run -p codex-client`). The server accepts newline-delimited JSON `Submission` objects and streams back `Event` messages. Because it uses the same `ConversationManager` as the CLI, plugins, MCP servers, and other runtime features remain available when Codex runs in this remote mode.


### PR DESCRIPTION
## Summary
- note server/client binaries that preserve full features when running Codex remotely
- describe remote server/client workflow in Rust CLI docs and advanced guide

## Testing
- `cargo test -p codex-server`
- `cargo test -p codex-client`
- `cargo test -p codex-core` *(fails: suite::client::azure_overrides_assign_properties_used_for_responses_url, suite::client::env_var_overrides_loaded_auth)*

------
https://chatgpt.com/codex/tasks/task_b_68b2a08b923483298712e6448340efb5