### PR TITLE
fix: handle tool schema generation errors

### DIFF
--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -163,6 +163,23 @@ impl McpProcess {
         .await
     }
 
+    /// Send a `callTool` request with arbitrary arguments.
+    pub async fn send_raw_call_tool_request(
+        &mut self,
+        name: &str,
+        arguments: Option<serde_json::Value>,
+    ) -> anyhow::Result<i64> {
+        let params = CallToolRequestParams {
+            name: name.to_string(),
+            arguments,
+        };
+        self.send_request(
+            mcp_types::CallToolRequest::METHOD,
+            Some(serde_json::to_value(params)?),
+        )
+        .await
+    }
+
     /// Send a `newConversation` JSON-RPC request.
     pub async fn send_new_conversation_request(
         &mut self,


### PR DESCRIPTION
## Summary
- return `Result` from codex tool schema builders instead of panicking
- surface schema generation errors in `MessageProcessor`
- add regression test for malformed codex tool input

## Testing
- `cargo test -p codex-mcp-server`

------
https://chatgpt.com/codex/tasks/task_b_68b3bf27fa98832980c7c23fa4372292