### PR TITLE
feat(mcp-server): handle exec approval action and content

### DIFF
--- a/codex-rs/mcp-server/tests/suite/codex_tool.rs
+++ b/codex-rs/mcp-server/tests/suite/codex_tool.rs
@@ -107,7 +107,10 @@ async fn shell_command_approval_triggers_elicitation() -> anyhow::Result<()> {
         .send_response(
             elicitation_request_id,
             serde_json::to_value(ExecApprovalResponse {
-                decision: ReviewDecision::Approved,
+                action: "submit".to_string(),
+                content: json!({
+                    "decision": ReviewDecision::Approved,
+                }),
             })?,
         )
         .await?;

--- a/codex-rs/mcp-server/tests/suite/exec_approval.rs
+++ b/codex-rs/mcp-server/tests/suite/exec_approval.rs
@@ -1,0 +1,17 @@
+use codex_core::protocol::ReviewDecision;
+use codex_mcp_server::ExecApprovalResponse;
+use serde_json::json;
+
+#[test]
+fn exec_approval_response_deserializes() {
+    let value = json!({
+        "action": "submit",
+        "content": { "decision": "approved" }
+    });
+
+    let response: ExecApprovalResponse = serde_json::from_value(value).unwrap();
+    assert_eq!(response.action, "submit");
+    let decision: ReviewDecision =
+        serde_json::from_value(response.content["decision"].clone()).unwrap();
+    assert_eq!(decision, ReviewDecision::Approved);
+}

--- a/codex-rs/mcp-server/tests/suite/mod.rs
+++ b/codex-rs/mcp-server/tests/suite/mod.rs
@@ -4,6 +4,7 @@ mod codex_message_processor_flow;
 mod codex_tool;
 mod config;
 mod create_conversation;
+mod exec_approval;
 mod interrupt;
 mod login;
 mod send_message;


### PR DESCRIPTION
## Summary
- Capture `action` and `content` in `ExecApprovalResponse`
- Parse decision from response content before forwarding to Codex
- Test `ExecApprovalResponse` deserialization

## Testing
- `cargo test -p codex-mcp-server`


------
https://chatgpt.com/codex/tasks/task_b_68b3bf2beb908329801d783b416f368c