### PR TITLE
feat: support read restrictions in Linux sandbox

### DIFF
--- a/codex-rs/common/src/sandbox_summary.rs
+++ b/codex-rs/common/src/sandbox_summary.rs
@@ -5,6 +5,7 @@ pub fn summarize_sandbox_policy(sandbox_policy: &SandboxPolicy) -> String {
         SandboxPolicy::DangerFullAccess => "danger-full-access".to_string(),
         SandboxPolicy::ReadOnly => "read-only".to_string(),
         SandboxPolicy::WorkspaceWrite {
+            read_roots: _,
             writable_roots,
             network_access,
             exclude_tmpdir_env_var,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -578,11 +578,13 @@ impl ConfigToml {
             SandboxMode::ReadOnly => SandboxPolicy::new_read_only_policy(),
             SandboxMode::WorkspaceWrite => match self.sandbox_workspace_write.as_ref() {
                 Some(SandboxWorkspaceWrite {
+                    read_roots,
                     writable_roots,
                     network_access,
                     exclude_tmpdir_env_var,
                     exclude_slash_tmp,
                 }) => SandboxPolicy::WorkspaceWrite {
+                    read_roots: read_roots.clone(),
                     writable_roots: writable_roots.clone(),
                     network_access: *network_access,
                     exclude_tmpdir_env_var: *exclude_tmpdir_env_var,
@@ -1178,6 +1180,7 @@ exclude_slash_tmp = true
         let sandbox_mode_override = None;
         assert_eq!(
             SandboxPolicy::WorkspaceWrite {
+                read_roots: vec![],
                 writable_roots: vec![PathBuf::from("/my/workspace")],
                 network_access: false,
                 exclude_tmpdir_env_var: true,

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -119,6 +119,8 @@ pub struct Tui {
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SandboxWorkspaceWrite {
     #[serde(default)]
+    pub read_roots: Vec<PathBuf>,
+    #[serde(default)]
     pub writable_roots: Vec<PathBuf>,
     #[serde(default)]
     pub network_access: bool,

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -326,6 +326,7 @@ mod tests {
         // Policy limited to the workspace only; exclude system temp roots so
         // only `cwd` is writable by default.
         let policy_workspace_only = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![],
             network_access: false,
             exclude_tmpdir_env_var: true,
@@ -347,6 +348,7 @@ mod tests {
         // With the parent dir explicitly added as a writable root, the
         // outside write should be permitted.
         let policy_with_parent = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![parent.clone()],
             network_access: false,
             exclude_tmpdir_env_var: true,
@@ -388,6 +390,7 @@ mod tests {
             ApplyPatchAction::new_add_for_test(&cwd.join("inner.txt"), "".to_string());
 
         let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![],
             network_access: false,
             exclude_tmpdir_env_var: true,
@@ -414,6 +417,7 @@ mod tests {
             ApplyPatchAction::new_add_for_test(&parent.join("outside.txt"), "".to_string());
 
         let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![],
             network_access: false,
             exclude_tmpdir_env_var: true,

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -153,6 +153,7 @@ mod tests {
         // Build a policy that only includes the two test roots as writable and
         // does not automatically include defaults TMPDIR or /tmp.
         let policy = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![root_with_git.clone(), root_without_git.clone()],
             network_access: false,
             exclude_tmpdir_env_var: true,
@@ -228,6 +229,7 @@ mod tests {
         // use the default ones (cwd and TMPDIR) and verifies the `.git` check
         // is done properly for cwd.
         let policy = SandboxPolicy::WorkspaceWrite {
+            read_roots: vec![],
             writable_roots: vec![],
             network_access: false,
             exclude_tmpdir_env_var: false,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -385,6 +385,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() {
             cwd: None,
             approval_policy: Some(AskForApproval::Never),
             sandbox_policy: Some(SandboxPolicy::WorkspaceWrite {
+                read_roots: vec![],
                 writable_roots: vec![writable.path().to_path_buf()],
                 network_access: true,
                 exclude_tmpdir_env_var: true,
@@ -513,6 +514,7 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() {
             cwd: new_cwd.path().to_path_buf(),
             approval_policy: AskForApproval::Never,
             sandbox_policy: SandboxPolicy::WorkspaceWrite {
+                read_roots: vec![],
                 writable_roots: vec![writable.path().to_path_buf()],
                 network_access: true,
                 exclude_tmpdir_env_var: true,

--- a/codex-rs/core/tests/suite/seatbelt.rs
+++ b/codex-rs/core/tests/suite/seatbelt.rs
@@ -76,6 +76,7 @@ async fn if_parent_of_repo_is_writable_then_dot_git_folder_is_writable() {
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let test_scenario = create_test_scenario(&tmp);
     let policy = SandboxPolicy::WorkspaceWrite {
+        read_roots: vec![],
         writable_roots: vec![test_scenario.repo_parent.clone()],
         network_access: false,
         exclude_tmpdir_env_var: true,
@@ -102,6 +103,7 @@ async fn if_git_repo_is_writable_root_then_dot_git_folder_is_read_only() {
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let test_scenario = create_test_scenario(&tmp);
     let policy = SandboxPolicy::WorkspaceWrite {
+        read_roots: vec![],
         writable_roots: vec![test_scenario.repo_root.clone()],
         network_access: false,
         exclude_tmpdir_env_var: true,

--- a/codex-rs/exec/tests/suite/sandbox.rs
+++ b/codex-rs/exec/tests/suite/sandbox.rs
@@ -54,6 +54,7 @@ async fn python_multiprocessing_lock_works_under_sandbox() {
     let writable_roots = vec![PathBuf::from("/dev/shm")];
 
     let policy = SandboxPolicy::WorkspaceWrite {
+        read_roots: vec![],
         writable_roots,
         network_access: false,
         exclude_tmpdir_env_var: false,


### PR DESCRIPTION
## Summary
- allow SandboxPolicy to specify readable roots
- apply separate read and write rules in Linux Landlock sandbox
- test read access is denied when outside allowed roots

## Testing
- `cargo test -p codex-linux-sandbox` *(fails: Sandbox(LandlockRestrict))*
- `cargo test -p codex-core` *(fails: env var NotPresent; prompt_tools assertion)*

------
https://chatgpt.com/codex/tasks/task_b_68b3c3f71bdc8329b65d2cefd3a8abf0