### PR TITLE
fix: handle unsupported WinAPI scroll regions

### DIFF
--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -4,6 +4,8 @@ use std::io::Write;
 
 use crate::tui;
 use crossterm::Command;
+#[cfg(windows)]
+use crossterm::ansi_support::supports_ansi;
 use crossterm::cursor::MoveTo;
 use crossterm::queue;
 use crossterm::style::Color as CColor;
@@ -123,13 +125,15 @@ impl Command for SetScrollRegion {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> std::io::Result<()> {
-        panic!("tried to execute SetScrollRegion command using WinAPI, use ANSI instead");
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "tried to execute SetScrollRegion command using WinAPI, use ANSI instead",
+        ))
     }
 
     #[cfg(windows)]
     fn is_ansi_code_supported(&self) -> bool {
-        // TODO(nornagon): is this supported on Windows?
-        true
+        supports_ansi()
     }
 }
 
@@ -143,13 +147,15 @@ impl Command for ResetScrollRegion {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> std::io::Result<()> {
-        panic!("tried to execute ResetScrollRegion command using WinAPI, use ANSI instead");
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "tried to execute ResetScrollRegion command using WinAPI, use ANSI instead",
+        ))
     }
 
     #[cfg(windows)]
     fn is_ansi_code_supported(&self) -> bool {
-        // TODO(nornagon): is this supported on Windows?
-        true
+        supports_ansi()
     }
 }
 

--- a/codex-rs/tui/tests/insert_history.rs
+++ b/codex-rs/tui/tests/insert_history.rs
@@ -1,0 +1,20 @@
+#![cfg(windows)]
+
+use std::io;
+
+use codex_tui::insert_history::{ResetScrollRegion, SetScrollRegion};
+use crossterm::Command;
+
+#[test]
+fn set_scroll_region_execute_winapi_returns_error() {
+    let cmd = SetScrollRegion(1..2);
+    let err = cmd.execute_winapi().expect_err("expected error");
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+}
+
+#[test]
+fn reset_scroll_region_execute_winapi_returns_error() {
+    let cmd = ResetScrollRegion;
+    let err = cmd.execute_winapi().expect_err("expected error");
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+}


### PR DESCRIPTION
## Summary
- return io::Error instead of panicking when executing scroll region commands via WinAPI
- check ANSI capability at runtime
- add Windows-only tests for error propagation

## Testing
- `cargo test -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_b_68b3c3fa3b788329b57bf9dd03d3e11d