### PR TITLE
fix: deduplicate PATH entries in codex CLI

### DIFF
--- a/codex-cli/test/getUpdatedPath.test.js
+++ b/codex-cli/test/getUpdatedPath.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { getUpdatedPath } from "../bin/codex.js";
+
+test("removes duplicate directories when updating PATH", () => {
+  const pathSep = process.platform === "win32" ? ";" : ":";
+  const original = process.env.PATH;
+  try {
+    process.env.PATH = ["b", "c"].join(pathSep);
+    const result = getUpdatedPath(["a", "b"]);
+    assert.strictEqual(result, ["a", "b", "c"].join(pathSep));
+  } finally {
+    process.env.PATH = original;
+  }
+});


### PR DESCRIPTION
## Summary
- ensure PATH updates deduplicate directories via Set
- add unit test covering duplicate removal

## Testing
- `npx prettier codex-cli/bin/codex.js codex-cli/test/getUpdatedPath.test.js -w`
- `node --test codex-cli/test/getUpdatedPath.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b3c8b7f5648329816f17065c30d962