### PR TITLE
feat(execpolicy): borrow Opt when unpacking

### DIFF
--- a/codex-rs/execpolicy/src/lib.rs
+++ b/codex-rs/execpolicy/src/lib.rs
@@ -23,7 +23,7 @@ pub use error::Error;
 pub use error::Result;
 pub use exec_call::ExecCall;
 pub use execv_checker::ExecvChecker;
-pub use opt::Opt;
+pub use opt::{Opt, OptMeta};
 pub use policy::Policy;
 pub use policy_parser::PolicyParser;
 pub use program::Forbidden;

--- a/codex-rs/execpolicy/src/policy_parser.rs
+++ b/codex-rs/execpolicy/src/policy_parser.rs
@@ -125,7 +125,7 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
         system_path: Option<UnpackList<String>>,
         option_bundling: Option<bool>,
         combined_format: Option<bool>,
-        options: Option<UnpackList<Opt>>,
+        options: Option<UnpackList<&'v Opt>>,
         args: Option<UnpackList<ArgMatcher>>,
         forbidden: Option<String>,
         should_match: Option<UnpackList<UnpackList<String>>>,
@@ -142,7 +142,7 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
         for opt in options {
             let name = opt.name().to_string();
             if allowed_options
-                .insert(opt.name().to_string(), opt)
+                .insert(name.clone(), opt.to_owned())
                 .is_some()
             {
                 return Err(anyhow::format_err!("duplicate flag: {name}"));

--- a/codex-rs/execpolicy/tests/opt.rs
+++ b/codex-rs/execpolicy/tests/opt.rs
@@ -1,0 +1,15 @@
+use codex_execpolicy::{Opt, OptMeta};
+use starlark::values::{Heap, UnpackValue, ValueLike};
+
+#[test]
+fn unpack_borrowed_opt() {
+    let heap = Heap::new();
+    let value = heap.alloc(Opt::new("-h".to_owned(), OptMeta::Flag, true));
+
+    let direct = value.downcast_ref::<Opt>().unwrap();
+    let unpacked = <&Opt as UnpackValue>::unpack_value(value).unwrap().unwrap();
+
+    assert!(std::ptr::eq(direct, unpacked));
+    let owned = unpacked.to_owned();
+    assert_eq!(owned, *unpacked);
+}


### PR DESCRIPTION
## Summary
- support unpacking borrowed `Opt` values without cloning
- allow converting borrowed `Opt` to owned form
- test borrowed `Opt` unpacking

## Testing
- `cargo test -p codex-execpolicy`


------
https://chatgpt.com/codex/tasks/task_b_68b3c8bac20c832980634157188bca3f