### PR TITLE
fix(cli): execute symlinked entrypoints

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -2,7 +2,8 @@
 // Unified entry point for the Codex CLI.
 
 import path from "path";
-import { fileURLToPath, pathToFileURL } from "url";
+import { fileURLToPath } from "url";
+import { realpathSync } from "fs";
 
 // __dirname equivalent in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -157,9 +158,10 @@ async function main() {
   }
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
-  await main();
+if (process.argv[1]) {
+  const invokedPath = realpathSync(process.argv[1]);
+  const currentPath = fileURLToPath(import.meta.url);
+  if (invokedPath === currentPath) {
+    await main();
+  }
 }

--- a/codex-cli/test/cli-symlink.test.js
+++ b/codex-cli/test/cli-symlink.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { mkdtempSync, symlinkSync, unlinkSync, rmdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test("executes main when invoked via symlink", () => {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "codex-cli-test-"));
+  const linkPath = path.join(tmpDir, "codex");
+  symlinkSync(path.join(__dirname, "../bin/codex.js"), linkPath);
+  const result = spawnSync(process.execPath, [linkPath], { encoding: "utf8" });
+  try {
+    assert.strictEqual(result.status, 1);
+  } finally {
+    unlinkSync(linkPath);
+    rmdirSync(tmpDir);
+  }
+});


### PR DESCRIPTION
## Summary
- ensure CLI main runs when invoked via symlinked bin
- add test covering symlinked invocation

## Testing
- `node --test`
- `pnpm run build` *(fails: Missing script: build)*

------
https://chatgpt.com/codex/tasks/task_b_68b3e3eafcb883299ac783270296e876