### PR TITLE
feat: add codex server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +275,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +496,22 @@ dependencies = [
 [[package]]
 name = "codex-server"
 version = "0.1.0"
+dependencies = [
+ "axum",
+ "codex-core",
+ "codex-ollama",
+ "codex-redis",
+ "httpmock",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -460,6 +543,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -737,8 +829,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap",
+ "http 0.2.12",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -754,6 +846,21 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -780,13 +887,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -817,7 +958,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper",
+ "hyper 0.14.32",
  "lazy_static",
  "levenshtein",
  "log",
@@ -841,8 +982,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -855,16 +996,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -976,12 +1154,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1126,10 +1314,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+dependencies = [
+ "base64",
+ "hyper 0.14.32",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1181,12 +1439,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1299,7 +1576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -1361,6 +1638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1668,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1697,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1460,9 +1768,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1476,7 +1784,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -1608,6 +1916,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1954,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1673,6 +2000,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -1770,6 +2103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +2182,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1944,7 +2292,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1959,6 +2307,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,8 +2340,21 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1981,6 +2364,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2020,6 +2429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "value-bag"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2445,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2458,6 +2879,26 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/crates/codex-core/src/config.rs
+++ b/crates/codex-core/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub data_path: PathBuf,
     /// Port the server should bind to.
     pub port: u16,
+    /// Optional RESP port for exposing raw Redis protocol.
+    pub resp_port: Option<u16>,
 }
 
 impl Default for Config {
@@ -29,6 +31,7 @@ impl Default for Config {
             store: StoreChoice::Memory,
             data_path: PathBuf::from("./data"),
             port: 0,
+            resp_port: None,
         }
     }
 }
@@ -49,6 +52,7 @@ struct PartialConfig {
     store: Option<StoreChoice>,
     data_path: Option<PathBuf>,
     port: Option<u16>,
+    resp_port: Option<u16>,
 }
 
 /// Errors that can occur while loading configuration.
@@ -106,6 +110,9 @@ impl Config {
         }
         if let Some(port) = partial.port {
             cfg.port = port;
+        }
+        if let Some(resp) = partial.resp_port {
+            cfg.resp_port = Some(resp);
         }
 
         Ok(cfg)

--- a/crates/codex-server/Cargo.toml
+++ b/crates/codex-server/Cargo.toml
@@ -4,3 +4,21 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+axum = { version = "0.7", features = ["json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+codex-core = { path = "../codex-core" }
+codex-ollama = { path = "../codex-ollama" }
+codex-redis = { path = "../codex-redis" }
+metrics = "0.21"
+metrics-exporter-prometheus = "0.12"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.11", features=["json"] }
+httpmock = "0.7"
+serde_json = "1"
+tempfile = "3"

--- a/crates/codex-server/src/lib.rs
+++ b/crates/codex-server/src/lib.rs
@@ -1,1 +1,332 @@
-pub fn placeholder() {}
+use std::{
+    net::SocketAddr,
+    sync::{Arc, OnceLock},
+};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    routing::{get, post},
+};
+use codex_core::Config;
+use codex_ollama::{LlmTier, Message, OllamaClient, Role};
+use codex_redis::Redis;
+use codex_redis::resp::Resp;
+use metrics::counter;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tracing::info;
+
+static METRICS: OnceLock<PrometheusHandle> = OnceLock::new();
+
+#[derive(Clone)]
+pub struct AppState {
+    pub ollama: Arc<OllamaClient>,
+    pub redis: Arc<Redis>,
+    pub metrics: PrometheusHandle,
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/embeddings", post(embeddings))
+        .route("/v1/vector/upsert", post(vector_upsert))
+        .route("/v1/vector/query", post(vector_query))
+        .route("/v1/chat", post(chat))
+        .route("/v1/rag/answer", post(rag_answer))
+        .route("/v1/admin/compact", post(admin_compact))
+        .route("/healthz", get(health))
+        .route("/metrics", get(metrics_endpoint))
+        .with_state(state)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmbeddingsRequest {
+    pub texts: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmbeddingsResponse {
+    pub embeddings: Vec<Vec<f32>>,
+}
+
+async fn embeddings(
+    State(state): State<AppState>,
+    Json(req): Json<EmbeddingsRequest>,
+) -> Json<EmbeddingsResponse> {
+    counter!("requests_total", 1, "endpoint" => "embeddings");
+    if req.texts.len() > 256 {
+        return Json(EmbeddingsResponse { embeddings: vec![] });
+    }
+    let embeddings = state.ollama.embed(&req.texts).await.unwrap_or_default();
+    Json(EmbeddingsResponse { embeddings })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VectorRecord {
+    pub id: u32,
+    pub values: Vec<f32>,
+    pub document: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpsertRequest {
+    pub vectors: Vec<VectorRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpsertResponse {
+    pub inserted: usize,
+}
+
+async fn vector_upsert(
+    State(state): State<AppState>,
+    Json(req): Json<UpsertRequest>,
+) -> Json<UpsertResponse> {
+    counter!("requests_total", 1, "endpoint" => "vector_upsert");
+    if req.vectors.len() > 2000 {
+        return Json(UpsertResponse { inserted: 0 });
+    }
+    if let Some(first) = req.vectors.first() {
+        let dim = first.values.len();
+        state.redis.execute(&vec![
+            "VEC.CREATE".into(),
+            "docs".into(),
+            dim.to_string(),
+            "4".into(),
+            "10".into(),
+        ]);
+    }
+    for v in &req.vectors {
+        let vec = v
+            .values
+            .iter()
+            .map(|f| f.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        state.redis.execute(&vec![
+            "VEC.ADD".into(),
+            "docs".into(),
+            v.id.to_string(),
+            vec,
+            v.document.clone(),
+        ]);
+    }
+    Json(UpsertResponse {
+        inserted: req.vectors.len(),
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryRequest {
+    pub vector: Vec<f32>,
+    pub top_k: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryHit {
+    pub id: u32,
+    pub document: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueryResponse {
+    pub results: Vec<QueryHit>,
+}
+
+async fn vector_query(
+    State(state): State<AppState>,
+    Json(req): Json<QueryRequest>,
+) -> Json<QueryResponse> {
+    counter!("requests_total", 1, "endpoint" => "vector_query");
+    let vec = req
+        .vector
+        .iter()
+        .map(|f| f.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let resp = state.redis.execute(&vec![
+        "VEC.SEARCH".into(),
+        "docs".into(),
+        vec,
+        req.top_k.to_string(),
+        "10".into(),
+    ]);
+    let mut results = Vec::new();
+    if let Resp::Array(Some(items)) = resp {
+        for item in items {
+            if let Resp::Array(Some(inner)) = item {
+                if inner.len() >= 2 {
+                    let id = match inner[0] {
+                        Resp::Integer(i) => i as u32,
+                        _ => 0,
+                    };
+                    let doc = match &inner[1] {
+                        Resp::Bulk(Some(b)) => String::from_utf8_lossy(b).to_string(),
+                        _ => String::new(),
+                    };
+                    results.push(QueryHit { id, document: doc });
+                }
+            }
+        }
+    }
+    Json(QueryResponse { results })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatRequest {
+    pub tier: Option<String>,
+    pub messages: Vec<Message>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatResponse {
+    pub reply: String,
+}
+
+fn parse_tier(t: Option<String>) -> LlmTier {
+    match t.as_deref() {
+        Some("low") => LlmTier::Low,
+        Some("medium") => LlmTier::Medium,
+        _ => LlmTier::High,
+    }
+}
+
+async fn chat(State(state): State<AppState>, Json(req): Json<ChatRequest>) -> Json<ChatResponse> {
+    counter!("requests_total", 1, "endpoint" => "chat");
+    let tier = parse_tier(req.tier);
+    let reply = state
+        .ollama
+        .chat(tier, &req.messages)
+        .await
+        .unwrap_or_default();
+    Json(ChatResponse { reply })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RagRequest {
+    pub question: String,
+    pub top_k: usize,
+    pub tier: Option<String>,
+    pub translate: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RagResponse {
+    pub answer: String,
+    pub contexts: Vec<String>,
+}
+
+async fn rag_answer(
+    State(state): State<AppState>,
+    Json(req): Json<RagRequest>,
+) -> Json<RagResponse> {
+    counter!("requests_total", 1, "endpoint" => "rag_answer");
+    let embed = state
+        .ollama
+        .embed(&[req.question.clone()])
+        .await
+        .unwrap_or_default();
+    let query_vec = embed.get(0).cloned().unwrap_or_default();
+    let vec = query_vec
+        .iter()
+        .map(|f| f.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let resp = state.redis.execute(&vec![
+        "VEC.SEARCH".into(),
+        "docs".into(),
+        vec,
+        req.top_k.to_string(),
+        "10".into(),
+    ]);
+    let mut contexts = Vec::new();
+    if let Resp::Array(Some(items)) = resp {
+        for item in items {
+            if let Resp::Array(Some(inner)) = item {
+                if inner.len() >= 2 {
+                    if let Resp::Bulk(Some(b)) = &inner[1] {
+                        contexts.push(String::from_utf8_lossy(b).to_string());
+                    }
+                }
+            }
+        }
+    }
+    let mut messages = Vec::new();
+    if !contexts.is_empty() {
+        messages.push(Message {
+            role: Role::System,
+            content: format!("Use the following context:\n{}", contexts.join("\n")),
+        });
+    }
+    messages.push(Message {
+        role: Role::User,
+        content: req.question,
+    });
+    let tier = parse_tier(req.tier);
+    let answer = state.ollama.chat(tier, &messages).await.unwrap_or_default();
+    Json(RagResponse { answer, contexts })
+}
+
+async fn admin_compact(State(state): State<AppState>) -> &'static str {
+    counter!("requests_total", 1, "endpoint" => "admin_compact");
+    state.redis.execute(&vec!["COMPACT".into()]);
+    "ok"
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn metrics_endpoint(State(state): State<AppState>) -> String {
+    state.metrics.render()
+}
+
+pub async fn start(
+    cfg: Config,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error>> {
+    let recorder = METRICS
+        .get_or_init(|| {
+            PrometheusBuilder::new()
+                .install_recorder()
+                .expect("metrics")
+        })
+        .clone();
+    let _ = tracing_subscriber::fmt::try_init();
+    let ollama = Arc::new(OllamaClient::new(cfg.backend_url.clone())?);
+    // startup checks
+    ollama.embed(&["start".into()]).await?;
+    ollama
+        .chat(
+            LlmTier::Low,
+            &[Message {
+                role: Role::User,
+                content: "ping".into(),
+            }],
+        )
+        .await?;
+
+    let redis = Arc::new(Redis::new(Some(cfg.data_path.join("aof.log"))));
+    if let Some(port) = cfg.resp_port {
+        let r = redis.clone();
+        tokio::spawn(async move {
+            let addr = format!("0.0.0.0:{}", port);
+            let _ = r.listen(&addr).await;
+        });
+    }
+
+    let state = AppState {
+        ollama: ollama.clone(),
+        redis: redis.clone(),
+        metrics: recorder.clone(),
+    };
+    let app = router(state);
+    let listener = TcpListener::bind(("0.0.0.0", cfg.port)).await?;
+    let addr = listener.local_addr()?;
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    info!("listening on {}", addr);
+    Ok((addr, handle))
+}

--- a/crates/codex-server/src/main.rs
+++ b/crates/codex-server/src/main.rs
@@ -1,3 +1,9 @@
-fn main() {
-    println!("Hello, world!");
+use codex_core::Config;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cfg = Config::load()?;
+    let (_addr, handle) = codex_server::start(cfg).await?;
+    handle.await?;
+    Ok(())
 }

--- a/crates/codex-server/tests/server.rs
+++ b/crates/codex-server/tests/server.rs
@@ -1,0 +1,114 @@
+use codex_core::Config;
+use codex_server::{
+    EmbeddingsRequest, EmbeddingsResponse, QueryRequest, QueryResponse, RagRequest, RagResponse,
+    UpsertRequest, VectorRecord, start,
+};
+use httpmock::{Method::POST, MockServer};
+use serde_json::json;
+
+#[tokio::test]
+async fn embed_upsert_query_rag_recovery() {
+    let mock = MockServer::start();
+    let _embed = mock.mock(|when, then| {
+        when.method(POST).path("/api/embeddings");
+        then.status(200)
+            .json_body(json!({"embeddings": [[1.0,0.0]]}));
+    });
+    let _chat = mock.mock(|when, then| {
+        when.method(POST).path("/api/chat");
+        then.status(200)
+            .json_body(json!({"message": {"role": "assistant", "content": "answer"}}));
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = Config {
+        backend_url: mock.base_url(),
+        data_path: dir.path().to_path_buf(),
+        port: 0,
+        resp_port: None,
+        ..Default::default()
+    };
+    let (addr, handle) = start(cfg.clone()).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{}", addr.port());
+
+    let emb: EmbeddingsResponse = client
+        .post(format!("{base}/v1/embeddings"))
+        .json(&EmbeddingsRequest {
+            texts: vec!["doc1".into()],
+        })
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(emb.embeddings.len(), 1);
+
+    let up = UpsertRequest {
+        vectors: vec![VectorRecord {
+            id: 1,
+            values: vec![1.0, 0.0],
+            document: "doc1".into(),
+        }],
+    };
+    client
+        .post(format!("{base}/v1/vector/upsert"))
+        .json(&up)
+        .send()
+        .await
+        .unwrap();
+
+    let q: QueryResponse = client
+        .post(format!("{base}/v1/vector/query"))
+        .json(&QueryRequest {
+            vector: vec![1.0, 0.0],
+            top_k: 1,
+        })
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(q.results[0].document, "doc1");
+
+    let r: RagResponse = client
+        .post(format!("{base}/v1/rag/answer"))
+        .json(&RagRequest {
+            question: "hello".into(),
+            top_k: 1,
+            tier: None,
+            translate: Some(false),
+        })
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r.contexts[0], "doc1");
+
+    handle.abort();
+    let _ = handle.await;
+
+    let (addr2, handle2) = start(cfg).await.unwrap();
+    let base2 = format!("http://127.0.0.1:{}", addr2.port());
+    let q2: QueryResponse = client
+        .post(format!("{base2}/v1/vector/query"))
+        .json(&QueryRequest {
+            vector: vec![1.0, 0.0],
+            top_k: 1,
+        })
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(q2.results[0].document, "doc1");
+
+    handle2.abort();
+    let _ = handle2.await;
+}


### PR DESCRIPTION
## Summary
- add codex-server binary providing embeddings, vector store, chat, rag, admin, and health endpoints
- wire metrics, logging, optional RESP listener, and config support
- include integration test covering embed→upsert→query→rag with restart recovery

## Testing
- `cargo test -p codex-core`
- `cargo test -p codex-server`


------
https://chatgpt.com/codex/tasks/task_b_68b41eff54c08329a8cda565458f4cca