### PR TITLE
feat(go): add HTTP client

### DIFF
--- a/clients/go/client.go
+++ b/clients/go/client.go
@@ -1,0 +1,169 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Client wraps HTTP access to the Codex server API.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a new Client with the given baseURL.
+func NewClient(baseURL string) *Client {
+	return &Client{BaseURL: strings.TrimRight(baseURL, "/"), HTTPClient: &http.Client{}}
+}
+
+// Message represents a chat message.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Reference represents a document reference returned by the server.
+type Reference struct {
+	ID       uint32 `json:"id,omitempty"`
+	Document string `json:"document"`
+}
+
+// Result represents a RAG answer with supporting references.
+type Result struct {
+	Answer     string      `json:"answer"`
+	References []Reference `json:"references"`
+}
+
+// VectorRecord represents a vector stored in the vector database.
+type VectorRecord struct {
+	ID       uint32    `json:"id"`
+	Values   []float32 `json:"values"`
+	Document string    `json:"document"`
+}
+
+func (c *Client) do(ctx context.Context, method, path string, reqBody, respBody interface{}) error {
+	var body io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, body)
+	if err != nil {
+		return err
+	}
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	if respBody != nil {
+		return json.NewDecoder(resp.Body).Decode(respBody)
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// Embed sends texts for embedding and returns their vector representations.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	req := struct {
+		Texts []string `json:"texts"`
+	}{Texts: texts}
+	var resp struct {
+		Embeddings [][]float32 `json:"embeddings"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/embeddings", &req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Embeddings, nil
+}
+
+// Upsert inserts vectors into the database and returns the count inserted.
+func (c *Client) Upsert(ctx context.Context, vectors []VectorRecord) (int, error) {
+	req := struct {
+		Vectors []VectorRecord `json:"vectors"`
+	}{Vectors: vectors}
+	var resp struct {
+		Inserted int `json:"inserted"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/vector/upsert", &req, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Inserted, nil
+}
+
+// Query searches the vector database and returns matching references.
+func (c *Client) Query(ctx context.Context, vector []float32, topK int) ([]Reference, error) {
+	req := struct {
+		Vector []float32 `json:"vector"`
+		TopK   int       `json:"top_k"`
+	}{Vector: vector, TopK: topK}
+	var resp struct {
+		Results []Reference `json:"results"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/vector/query", &req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}
+
+// Chat performs a chat completion using the provided messages.
+// Tier may be empty to use the default.
+func (c *Client) Chat(ctx context.Context, tier string, messages []Message) (string, error) {
+	req := struct {
+		Tier     *string   `json:"tier,omitempty"`
+		Messages []Message `json:"messages"`
+	}{Messages: messages}
+	if tier != "" {
+		req.Tier = &tier
+	}
+	var resp struct {
+		Reply string `json:"reply"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/chat", &req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Reply, nil
+}
+
+// RAGAnswer performs a retrieval-augmented generation request.
+func (c *Client) RAGAnswer(ctx context.Context, question string, topK int, tier string, translate bool) (Result, error) {
+	req := struct {
+		Question  string  `json:"question"`
+		TopK      int     `json:"top_k"`
+		Tier      *string `json:"tier,omitempty"`
+		Translate *bool   `json:"translate,omitempty"`
+	}{Question: question, TopK: topK}
+	if tier != "" {
+		req.Tier = &tier
+	}
+	if translate {
+		req.Translate = &translate
+	}
+	var resp struct {
+		Answer   string   `json:"answer"`
+		Contexts []string `json:"contexts"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/rag/answer", &req, &resp); err != nil {
+		return Result{}, err
+	}
+	refs := make([]Reference, len(resp.Contexts))
+	for i, doc := range resp.Contexts {
+		refs[i] = Reference{Document: doc}
+	}
+	return Result{Answer: resp.Answer, References: refs}, nil
+}

--- a/clients/go/client_test.go
+++ b/clients/go/client_test.go
@@ -1,0 +1,136 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEmbed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var req struct {
+			Texts []string `json:"texts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(req.Texts) != 1 || req.Texts[0] != "hi" {
+			t.Fatalf("bad request: %+v", req)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{{1, 2, 3}}})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	emb, err := c.Embed(context.Background(), []string{"hi"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(emb) != 1 || len(emb[0]) != 3 {
+		t.Fatalf("unexpected embeddings: %v", emb)
+	}
+}
+
+func TestUpsert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vector/upsert" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var req struct {
+			Vectors []VectorRecord `json:"vectors"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(req.Vectors) != 1 || req.Vectors[0].ID != 1 {
+			t.Fatalf("bad request: %+v", req)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"inserted": 1})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	n, err := c.Upsert(context.Background(), []VectorRecord{{ID: 1, Values: []float32{1, 2}, Document: "d"}})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 inserted, got %d", n)
+	}
+}
+
+func TestQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vector/query" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []Reference{{ID: 1, Document: "doc"}},
+		})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	res, err := c.Query(context.Background(), []float32{1, 2}, 1)
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res) != 1 || res[0].Document != "doc" {
+		t.Fatalf("unexpected result: %v", res)
+	}
+}
+
+func TestChat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"reply": "ok"})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	msg := []Message{{Role: "user", Content: "hi"}}
+	reply, err := c.Chat(context.Background(), "", msg)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if reply != "ok" {
+		t.Fatalf("unexpected reply: %s", reply)
+	}
+}
+
+func TestRAGAnswer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rag/answer" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"answer":   "42",
+			"contexts": []string{"doc"},
+		})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	res, err := c.RAGAnswer(context.Background(), "?", 1, "", false)
+	if err != nil {
+		t.Fatalf("RAGAnswer: %v", err)
+	}
+	if res.Answer != "42" || len(res.References) != 1 {
+		t.Fatalf("unexpected result: %v", res)
+	}
+}
+
+func ExampleClient_Chat() {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"reply": "hello"})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	msg := []Message{{Role: "user", Content: "hi"}}
+	reply, _ := c.Chat(context.Background(), "", msg)
+	fmt.Println(reply)
+	// Output: hello
+}

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -1,0 +1,3 @@
+module codex
+
+go 1.24.3


### PR DESCRIPTION
## Summary
- add Go module `codex` and HTTP client
- implement Embed, Upsert, Query, Chat, and RAGAnswer APIs with JSON handling
- include examples and unit tests using `httptest`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68b4323b57c08329924e4a203b74c6fd