### PR TITLE
feat: add HTTP CLI with end-to-end tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "codex-cli",
+  "version": "0.1.0",
+  "bin": {
+    "codex": "src/index.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+const { createHash } = require("crypto");
+const { createReadStream, statSync } = require("fs");
+
+const args = process.argv.slice(2);
+let host = "http://localhost:3000";
+const hIndex = args.indexOf("--host");
+if (hIndex !== -1) {
+  host = args[hIndex + 1];
+  args.splice(hIndex, 2);
+}
+
+async function request(path, options) {
+  const url = host + path;
+  try {
+    const res = await fetch(url, options);
+    if (!res.ok) {
+      console.error(`HTTP ${res.status} ${res.statusText}`);
+      process.exit(1);
+    }
+    return await res.json();
+  } catch (err) {
+    console.error(`Network error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+async function modelsList() {
+  const data = await request("/models", { method: "GET" });
+  console.log(JSON.stringify(data));
+}
+
+async function embed(text) {
+  const data = await request("/embed", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  const embedding = data.embedding || [];
+  const buf = Buffer.from(new Float32Array(embedding).buffer);
+  const hash = createHash("sha256").update(buf).digest("hex");
+  console.log(hash);
+}
+
+async function ingest(file) {
+  const size = statSync(file).size;
+  const stream = createReadStream(file);
+  let uploaded = 0;
+  stream.on("data", (chunk) => {
+    uploaded += chunk.length;
+    const percent = Math.round((uploaded / size) * 100);
+    process.stdout.write(`\r${percent}%`);
+  });
+  await request("/ingest", {
+    method: "POST",
+    headers: { "content-type": "application/octet-stream" },
+    body: stream,
+    duplex: "half",
+  });
+  process.stdout.write("\n");
+  console.log("ok");
+}
+
+async function ask(question) {
+  const data = await request("/ask", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ question }),
+  });
+  console.log(data.answer);
+}
+
+async function adminCompact() {
+  const data = await request("/admin/compact", { method: "POST" });
+  console.log(data.status || "ok");
+}
+
+function usage() {
+  console.log(`Usage:
+  models list
+  embed <text>
+  ingest <file>
+  ask <question>
+  admin compact
+`);
+  process.exit(1);
+}
+
+async function main() {
+  const cmd = args.shift();
+  switch (cmd) {
+    case "models":
+      if (args.shift() === "list") await modelsList();
+      else usage();
+      break;
+    case "embed":
+      if (args.length) await embed(args.join(" "));
+      else usage();
+      break;
+    case "ingest":
+      if (args.length) await ingest(args[0]);
+      else usage();
+      break;
+    case "ask":
+      if (args.length) await ask(args.join(" "));
+      else usage();
+      break;
+    case "admin":
+      if (args.shift() === "compact") await adminCompact();
+      else usage();
+      break;
+    default:
+      usage();
+  }
+}
+
+main();

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -1,0 +1,114 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const { createServer } = require("http");
+const { execFile } = require("child_process");
+const { writeFileSync, unlinkSync } = require("fs");
+const { tmpdir } = require("os");
+const { join } = require("path");
+const crypto = require("crypto");
+
+function startServer() {
+  const server = createServer((req, res) => {
+    const { method, url } = req;
+    if (method === "GET" && url === "/models") {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ models: ["m1", "m2"] }));
+    } else if (method === "POST" && url === "/embed") {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ embedding: [1, 2, 3, 4] }));
+      });
+    } else if (method === "POST" && url === "/ingest") {
+      req.on("data", () => {});
+      req.on("end", () => {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ status: "ok" }));
+      });
+    } else if (method === "POST" && url === "/ask") {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ answer: "42" }));
+      });
+    } else if (method === "POST" && url === "/admin/compact") {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ status: "compacted" }));
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+function runCli(port, args) {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [
+        require.resolve("../src/index.js"),
+        "--host",
+        `http://localhost:${port}`,
+        ...args,
+      ],
+      { encoding: "utf8" },
+      (error, stdout, stderr) => {
+        const status = error ? error.code || 1 : 0;
+        resolve({ stdout, stderr, status });
+      },
+    );
+  });
+}
+
+test("models list", async () => {
+  const { server, port } = await startServer();
+  const out = await runCli(port, ["models", "list"]);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /m1/);
+  await new Promise((r) => server.close(r));
+});
+
+test("embed checksum", async () => {
+  const { server, port } = await startServer();
+  const out = await runCli(port, ["embed", "hello"]);
+  assert.equal(out.status, 0);
+  const buf = Buffer.from(new Float32Array([1, 2, 3, 4]).buffer);
+  const expected = crypto.createHash("sha256").update(buf).digest("hex");
+  assert.match(out.stdout, new RegExp(expected));
+  await new Promise((r) => server.close(r));
+});
+
+test("ingest progress", async () => {
+  const { server, port } = await startServer();
+  const file = join(tmpdir(), "ingest.txt");
+  writeFileSync(file, "data");
+  const out = await runCli(port, ["ingest", file]);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /100%/);
+  unlinkSync(file);
+  await new Promise((r) => server.close(r));
+});
+
+test("ask", async () => {
+  const { server, port } = await startServer();
+  const out = await runCli(port, ["ask", "why"]);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /42/);
+  await new Promise((r) => server.close(r));
+});
+
+test("admin compact", async () => {
+  const { server, port } = await startServer();
+  const out = await runCli(port, ["admin", "compact"]);
+  assert.equal(out.status, 0);
+  assert.match(out.stdout, /compacted/);
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary
- add Node-based CLI for listing models, embedding text, ingesting files, asking questions, and compacting admin state
- include progress output and checksum generation
- add end-to-end tests against a mock HTTP server

## Testing
- `npx prettier --check cli/package.json cli/src/index.js cli/test/cli.test.js`
- `node --test cli/test/cli.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b43d3233408329889e56fa9329c54b