### PR TITLE
docs: add examples and server guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
   - [Tracing / verbose logging](./docs/advanced.md#tracing--verbose-logging)
   - [Model Context Protocol (MCP)](./docs/advanced.md#model-context-protocol-mcp)
 - [**Zero data retention (ZDR)**](./docs/zdr.md)
+- [**Server & API**](./docs/server.md)
 - [**Contributing**](./docs/contributing.md)
 - [**Install & build**](./docs/install.md)
   - [System Requirements](./docs/install.md#system-requirements)

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,70 @@
+# Server and CLI usage
+
+## Configuration defaults
+
+Codex server reads `~/.codex/config.toml`. If the file is missing, these defaults are used:
+
+| Key               | Default value           |
+| ----------------- | ----------------------- |
+| `backend_url`     | `http://localhost:8000` |
+| `chat_model`      | `gpt-4o`                |
+| `embedding_model` | `nomic-embed-text`      |
+| `store`           | `memory`                |
+| `data_path`       | `./data`                |
+| `port`            | `0` (choose random)     |
+| `resp_port`       | _unset_                 |
+
+An example config lives at [`examples/config.toml`](../examples/config.toml).
+
+## Model tier mapping
+
+When calling the chat endpoint, the `tier` parameter selects a model derived from
+`chat_model`:
+
+| Tier     | Resolved model         |
+| -------- | ---------------------- |
+| `low`    | `${chat_model}-low`    |
+| `medium` | `${chat_model}-medium` |
+| `high`   | `${chat_model}`        |
+
+## API and CLI
+
+The server exposes a REST API:
+
+- `POST /v1/embeddings` – body matches [`EmbeddingsRequest`](../examples/embed.json).
+- `POST /v1/vector/upsert` – body matches [`UpsertRequest`](../examples/ingest.json).
+- `POST /v1/rag/answer` – body matches [`RagRequest`](../examples/pipeline.json).
+- `POST /v1/chat`
+- `POST /v1/vector/query`
+- `POST /v1/admin/compact`
+
+The Node CLI in [`cli/src/index.js`](../cli/src/index.js) wraps these endpoints:
+
+| Command                | Endpoint              |
+| ---------------------- | --------------------- |
+| `codex models list`    | `GET /models`         |
+| `codex embed <text>`   | `POST /embed`         |
+| `codex ingest <file>`  | `POST /ingest`        |
+| `codex ask <question>` | `POST /ask`           |
+| `codex admin compact`  | `POST /admin/compact` |
+
+## Pulling Ollama models
+
+Ensure required models are available before starting the server:
+
+```bash
+ollama pull gpt-4o
+ollama pull gpt-4o-low
+ollama pull gpt-4o-medium
+ollama pull nomic-embed-text
+```
+
+## Running tests
+
+```bash
+# Rust crates
+cargo test -p codex-ollama
+
+# CLI tests
+cd cli && npm test
+```

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,9 @@
+# Sample Codex server configuration
+backend_url = "http://localhost:8000"
+chat_model = "gpt-4o"
+embedding_model = "nomic-embed-text"
+store = "memory"
+data_path = "./data"
+port = 0
+# resp_port can be set to expose a raw RESP endpoint
+# resp_port = 6380

--- a/examples/embed.json
+++ b/examples/embed.json
@@ -1,0 +1,3 @@
+{
+  "texts": ["hello world"]
+}

--- a/examples/ingest.json
+++ b/examples/ingest.json
@@ -1,0 +1,9 @@
+{
+  "vectors": [
+    {
+      "id": 1,
+      "values": [0.1, 0.2, 0.3],
+      "document": "Example document text"
+    }
+  ]
+}

--- a/examples/pipeline.json
+++ b/examples/pipeline.json
@@ -1,0 +1,6 @@
+{
+  "question": "Where is data stored?",
+  "top_k": 3,
+  "tier": "medium",
+  "translate": false
+}


### PR DESCRIPTION
## Summary
- add sample config, pipeline, and ingestion specs under examples/
- document server configuration defaults, model tier mapping, API paths, and CLI usage
- link new server docs from README

## Testing
- `npx prettier --write docs/server.md README.md examples/pipeline.json examples/ingest.json examples/embed.json`
- `cargo test -p codex-ollama`
- `cd cli && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b55a467c2883298179cc7b9dc56c30