### PR TITLE
chore: set Rust edition to 2021

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -28,9 +28,9 @@ resolver = "2"
 version = "0.0.0"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
-# crates created with `cargo new -w ...` automatically inherit the 2024
+# crates created with `cargo new -w ...` automatically inherit the 2021
 # edition.
-edition = "2024"
+edition = "2021"
 
 [workspace.lints]
 rust = {}

--- a/crates/codex-core/Cargo.toml
+++ b/crates/codex-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-core"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/codex-ollama/Cargo.toml
+++ b/crates/codex-ollama/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-ollama"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }

--- a/crates/codex-redis-vector/Cargo.toml
+++ b/crates/codex-redis-vector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-redis-vector"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/crates/codex-redis/Cargo.toml
+++ b/crates/codex-redis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-redis"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "net", "io-util", "time"] }

--- a/crates/codex-server/Cargo.toml
+++ b/crates/codex-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-server"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 axum = { version = "0.7", features = ["json"] }


### PR DESCRIPTION
## Summary
- use Rust 2021 edition for all crates under `crates/`
- align `codex-rs` workspace package with Rust 2021

## Testing
- `cargo build --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_b_68b579495bcc8329a1486d7eb8b010a0