### PR TITLE
fix: guard platform-specific sandboxes

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod exec_env;
 mod flags;
 pub mod git_info;
 mod is_safe_command;
+#[cfg(target_os = "linux")]
 pub mod landlock;
 mod mcp_connection_manager;
 mod mcp_tool_call;
@@ -53,6 +54,7 @@ pub mod plan_tool;
 pub mod project_doc;
 mod rollout;
 pub(crate) mod safety;
+#[cfg(target_os = "macos")]
 pub mod seatbelt;
 pub mod shell;
 pub mod spawn;


### PR DESCRIPTION
## Summary
- cfg-gate Linux landlock and macOS seatbelt modules
- conditionally call platform sandbox helpers in exec and CLI

## Testing
- `cargo build --workspace`
- `cargo test --workspace --no-run`
- `cargo build --workspace --target x86_64-apple-darwin` *(fails: cc unrecognized options)*
- `cargo build --workspace --target x86_64-pc-windows-gnu` *(fails: dlltool missing)*
- `cargo test --workspace --target x86_64-apple-darwin --no-run` *(fails: cc unrecognized options)*
- `cargo test --workspace --target x86_64-pc-windows-gnu --no-run` *(fails: dlltool missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b57fcf0c288329bdedfa9942a6bf2e