### PR TITLE
fix: guard unix-specific test

### DIFF
--- a/codex-rs/mcp-server/tests/suite/codex_message_processor_flow.rs
+++ b/codex-rs/mcp-server/tests/suite/codex_message_processor_flow.rs
@@ -347,9 +347,11 @@ async fn test_send_user_turn_changes_approval_policy_behavior() {
     .expect("task_complete 2 notification");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_invalid_path_serialization_fails() {
     use std::ffi::OsString;
+    #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
 
     let invalid = OsString::from_vec(vec![0xff]);


### PR DESCRIPTION
## Summary
- limit invalid path serialization test to unix targets

## Testing
- `cargo build -p codex-mcp-server`
- `cargo test -p codex-mcp-server`
- `cargo build -p codex-mcp-server --target x86_64-pc-windows-gnu`
- `cargo test -p codex-mcp-server --target x86_64-pc-windows-gnu --no-run`


------
https://chatgpt.com/codex/tasks/task_b_68b65872ad3c8329ae8b3c2d671d7648