### PR TITLE
fix(file-search): show directory contents on Windows without a pattern

### DIFF
--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -82,8 +82,9 @@ pub async fn run_main<T: Reporter>(
             #[cfg(windows)]
             {
                 Command::new("cmd")
-                    .arg("/c")
-                    .arg(search_directory)
+                    .arg("/C")
+                    .arg("dir")
+                    .current_dir(search_directory)
                     .stdout(std::process::Stdio::inherit())
                     .stderr(std::process::Stdio::inherit())
                     .status()


### PR DESCRIPTION
## Summary
- run `cmd /C dir` from the search directory when no pattern is provided on Windows

## Testing
- `cargo test -p codex-file-search`
- `cargo run -p codex-file-search -- -C file-search`
- `cargo check -p codex-file-search --target x86_64-pc-windows-gnu`


------
https://chatgpt.com/codex/tasks/task_b_68b6b45a9ac48329ab98ccf9c47df8af