### PR TITLE
fix: provide default env vars for unsupported OS targets

### DIFF
--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -440,6 +440,9 @@ const DEFAULT_ENV_VARS: &[&str] = &[
     "TMP",
 ];
 
+#[cfg(not(any(unix, windows)))]
+const DEFAULT_ENV_VARS: &[&str] = &[];
+
 /// `extra_env` comes from the config for an entry in `mcp_servers` in
 /// `config.toml`.
 fn create_env_for_mcp_server(


### PR DESCRIPTION
## Summary
- add empty DEFAULT_ENV_VARS for non-Unix, non-Windows builds

## Testing
- `cargo check -p codex-mcp-client --target wasm32-unknown-unknown` *(fails: This wasm target is unsupported by mio)*

------
https://chatgpt.com/codex/tasks/task_b_68b6b86d7ff48329a2626ad8adc3f3c6