### PR TITLE
docs: note defaults for model capability flags

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -6,6 +6,7 @@ use crate::config_types::EditMode;
 use crate::config_types::History;
 use crate::config_types::McpServerConfig;
 use crate::config_types::ModelRole;
+use crate::config_types::ModelCapabilities;
 use crate::config_types::SandboxWorkspaceWrite;
 use crate::config_types::ShellEnvironmentPolicy;
 use crate::config_types::ShellEnvironmentPolicyToml;
@@ -13,9 +14,7 @@ use crate::config_types::Tui;
 use crate::config_types::UriBasedFileOpener;
 use crate::config_types::Verbosity;
 use crate::git_info::resolve_root_git_project_for_trust;
-use crate::model_family::{
-    built_in_model_capabilities, find_family_for_model, ModelCapabilities, ModelFamily,
-};
+use crate::model_family::{built_in_model_capabilities, find_family_for_model, ModelFamily};
 use crate::model_provider_info::built_in_model_providers;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::openai_model_info::get_model_info;
@@ -536,8 +535,10 @@ pub struct ConfigToml {
     /// Override to force-enable reasoning summaries for the configured model.
     pub model_supports_reasoning_summaries: Option<bool>,
     /// Top-level flag to require special apply_patch instructions for the configured model.
+    /// Defaults to `false`.
     pub model_needs_special_apply_patch_instructions: Option<bool>,
     /// Top-level flag to include the implicit local_shell tool for the configured model.
+    /// Defaults to `false`.
     pub model_uses_local_shell_tool: Option<bool>,
     /// Preferred apply_patch tool call style for the configured model.
     pub model_apply_patch_tool: Option<ApplyPatchToolConfig>,

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -11,6 +11,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use strum_macros::Display;
 
+/// Per-model capability flags that can be configured via `config.toml`.
+/// All boolean fields default to `false` when unspecified.
+pub use crate::model_family::ModelCapabilities;
+
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct McpServerConfig {
     pub command: String,

--- a/docs/config.md
+++ b/docs/config.md
@@ -382,6 +382,7 @@ model_supports_reasoning_summaries = true
 ## model_needs_special_apply_patch_instructions
 
 Force the inclusion of extra instructions describing the virtual `apply_patch` CLI for the configured model.
+Defaults to `false`.
 
 ```toml
 model_needs_special_apply_patch_instructions = true
@@ -390,6 +391,7 @@ model_needs_special_apply_patch_instructions = true
 ## model_uses_local_shell_tool
 
 When set, the implicit `local_shell` tool is always available to the configured model.
+Defaults to `false`.
 
 ```toml
 model_uses_local_shell_tool = true


### PR DESCRIPTION
## Summary
- re-export `ModelCapabilities` in config types
- clarify default `false` behavior for model capability flags

## Testing
- `cargo test -p codex-core` *(fails: mismatched closing delimiter in core/src/agents/builtin.rs)*

------
https://chatgpt.com/codex/tasks/task_b_68bb7ab5a6ac8329a4b69827fc76d87b