### PR TITLE
feat(cli): add model info subcommand

### DIFF
--- a/codex-rs/cli/src/commands/mod.rs
+++ b/codex-rs/cli/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/codex-rs/cli/src/commands/models/info.rs
+++ b/codex-rs/cli/src/commands/models/info.rs
@@ -1,0 +1,59 @@
+use codex_common::CliConfigOverrides;
+use codex_core::config::{Config, ConfigOverrides};
+
+pub fn run(cli_config_overrides: CliConfigOverrides) -> ! {
+    let cli_overrides = match cli_config_overrides.parse_overrides() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing -c overrides: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let config = match Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default()) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("Error loading configuration: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("model: {}", config.model);
+    println!("provider: {}", config.model_provider_id);
+    println!(
+        "context_window: {}",
+        config
+            .model_context_window
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!(
+        "max_output_tokens: {}",
+        config
+            .model_max_output_tokens
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!("capabilities:");
+    println!(
+        "  needs_special_apply_patch_instructions: {}",
+        config.model_family.needs_special_apply_patch_instructions
+    );
+    println!(
+        "  supports_reasoning_summaries: {}",
+        config.model_family.supports_reasoning_summaries
+    );
+    println!(
+        "  uses_local_shell_tool: {}",
+        config.model_family.uses_local_shell_tool
+    );
+    println!(
+        "  apply_patch_tool_type: {}",
+        match config.model_family.apply_patch_tool_type {
+            Some(t) => format!("{t:?}"),
+            None => "None".to_string(),
+        }
+    );
+
+    std::process::exit(0);
+}

--- a/codex-rs/cli/src/commands/models/mod.rs
+++ b/codex-rs/cli/src/commands/models/mod.rs
@@ -1,0 +1,25 @@
+use clap::{Parser, Subcommand};
+use codex_common::CliConfigOverrides;
+
+pub mod info;
+
+#[derive(Debug, Parser)]
+pub struct ModelsCli {
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
+
+    #[command(subcommand)]
+    pub command: ModelsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ModelsSubcommand {
+    /// Show details about the active model.
+    Info,
+}
+
+pub fn run(cli: ModelsCli) -> ! {
+    match cli.command {
+        ModelsSubcommand::Info => info::run(cli.config_overrides),
+    }
+}

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -18,6 +18,7 @@ use codex_tui::Cli as TuiCli;
 use std::path::PathBuf;
 
 use crate::proto::ProtoCli;
+mod commands;
 
 /// Codex CLI
 ///
@@ -68,6 +69,9 @@ enum Subcommand {
 
     /// Internal debugging commands.
     Debug(DebugArgs),
+
+    /// Model inspection commands.
+    Models(commands::models::ModelsCli),
 
     /// Apply the latest diff produced by Codex agent as a `git apply` to your local working tree.
     #[clap(visible_alias = "a")]
@@ -205,6 +209,10 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 .await?;
             }
         },
+        Some(Subcommand::Models(mut models_cli)) => {
+            prepend_config_flags(&mut models_cli.config_overrides, cli.config_overrides);
+            commands::models::run(models_cli);
+        }
         Some(Subcommand::Apply(mut apply_cli)) => {
             prepend_config_flags(&mut apply_cli.config_overrides, cli.config_overrides);
             run_apply_command(apply_cli, None).await?;


### PR DESCRIPTION
## Summary
- add `models info` subcommand to display active model configuration
- wire models subcommand into CLI

## Testing
- `cargo test -p codex-cli` *(fails: mismatched closing delimiter in codex-core)*

------
https://chatgpt.com/codex/tasks/task_b_68bb7e4e04448329bb7fd4ba537a9483