### PR TITLE
docs: document model overrides and capabilities

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -12,6 +12,9 @@ Core config.toml fields (codex-rs/core)
 - model_max_output_tokens: Optional u64; max output tokens.
 - model_provider_id: String key into model_providers map.
 - model_provider: Provider definition for HTTP client (derived from provider map + overrides).
+- model_needs_special_apply_patch_instructions: bool; include extra `apply_patch` instructions.
+- model_uses_local_shell_tool: bool; expose implicit `local_shell` tool.
+- model_apply_patch_tool: function|freeform|none; override `apply_patch` tool call style.
 - approval_policy: Command approval policy; values: untrusted|on-failure|on-request|never.
 - sandbox_policy: Tool sandbox policy; values: danger-full-access|read-only|workspace-write.
 - shell_environment_policy: Policy controlling env var inheritance; see section below.
@@ -101,7 +104,10 @@ Provider families
 
 - OpenAI/Chat-compatible backends: use wire_api: chat, tool choice auto, parallel_tool_calls disabled by default for tool serialism.
 - Responses API backends: use wire_api: responses; tool definitions expose strict schema when required.
-- OSS providers: configure base_url; set env_key to pick up API key from env.
+- OSS providers: configure base_url; set env_key to pick up API key from env. For
+  Ollama, Codex fetches model metadata (e.g., `num_ctx`) and fills in
+  `model_context_window` and other defaults automatically; override with
+  `model_*` keys if required.
 
 Server/Client split
 
@@ -142,3 +148,14 @@ export CODEX_SERVER_URL=http://localhost:8080
 ```
 
 codex-server (server side) embedding model selection depends on its `backend_url` and server configuration. Point it at your local models (e.g., Ollama) or API providers, and it will serve embeddings via `/v1/embeddings`.
+
+### Troubleshooting
+
+When model behaviour is unexpected, inspect Codex's cached metadata with:
+
+```shell
+codex models info <model>
+```
+
+This displays discovered details like `num_ctx`, helping verify automatic
+Ollama lookups and any `model_*` overrides.

--- a/docs/config.md
+++ b/docs/config.md
@@ -113,6 +113,19 @@ instance. If you do not specify a `model`, Codex automatically selects the
 first model reported by Ollama. When no models are installed, Codex downloads
 the default `gpt-oss:20b` model.
 
+When a model is selected, Codex queries Ollama for metadata such as
+`num_ctx` and uses it to populate `model_context_window` and
+`model_max_output_tokens` automatically. If the detected values are
+incorrect or you want to override other behaviour, set the relevant
+`model_*` keys:
+
+```toml
+model = "llama3.1"
+model_provider = "ollama"
+model_context_window = 8192        # override num_ctx
+model_uses_local_shell_tool = true # example capability override
+```
+
 Or a third-party provider (using a distinct environment variable for the API key):
 
 ```toml
@@ -814,3 +827,15 @@ planner = { model = "gpt-4o-mini" }
 name = "manager"
 model_role = "planner"
 ```
+
+## Troubleshooting
+
+If Codex reports unexpected context windows or capabilities, inspect what it
+knows about a model with:
+
+```shell
+codex models info <model>
+```
+
+The command lists the metadata (including `num_ctx`) that Codex uses when
+scheduling requests.

--- a/examples/config-capabilities.toml
+++ b/examples/config-capabilities.toml
@@ -1,0 +1,13 @@
+# Example Codex client configuration with custom model capabilities
+model = "llama3.1"
+model_provider = "ollama"
+
+[model_providers.ollama]
+name = "Ollama"
+base_url = "http://localhost:11434/v1"
+
+[model_capabilities."llama3.1"]
+uses_local_shell_tool = true
+needs_special_apply_patch_instructions = true
+apply_patch_tool_type = "function"
+


### PR DESCRIPTION
## Summary
- explain Ollama metadata discovery and model_* override keys
- add troubleshooting note on `codex models info`
- provide example config showing custom model capabilities

## Testing
- `cargo test -p codex-core`


------
https://chatgpt.com/codex/tasks/task_b_68bb8be93d2483298d67cdbf08612973