### PR TITLE
feat: add mul crate

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1171,10 +1171,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-mul"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-ollama"
 version = "0.0.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "bytes",
  "codex-core",
  "futures",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "server",
     "client",
     "tui",
+    "mul",
 ]
 resolver = "2"
 

--- a/codex-rs/mul/Cargo.toml
+++ b/codex-rs/mul/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "codex-mul"
+version = { workspace = true }
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/codex-rs/mul/src/lib.rs
+++ b/codex-rs/mul/src/lib.rs
@@ -1,0 +1,27 @@
+pub mod parser;
+pub mod serializer;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MulProgram {
+    pub statements: Vec<MulStatement>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MulStatement {
+    /// Assign a value to a variable.
+    Let { name: String, value: MulType },
+    /// Multiply two values and store the result in a variable.
+    Mul {
+        name: String,
+        left: MulType,
+        right: MulType,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MulType {
+    Number(i64),
+    Variable(String),
+}

--- a/codex-rs/mul/src/parser.rs
+++ b/codex-rs/mul/src/parser.rs
@@ -1,0 +1,6 @@
+use crate::MulProgram;
+use serde_json::Error;
+
+pub fn parse_program(input: &str) -> Result<MulProgram, Error> {
+    serde_json::from_str(input)
+}

--- a/codex-rs/mul/src/serializer.rs
+++ b/codex-rs/mul/src/serializer.rs
@@ -1,0 +1,6 @@
+use crate::MulProgram;
+use serde_json::Error;
+
+pub fn serialize_program(program: &MulProgram) -> Result<String, Error> {
+    serde_json::to_string(program)
+}


### PR DESCRIPTION
## Summary
- add new `codex-mul` crate defining `MulProgram` AST
- implement JSON parser and serializer for multiply programs
- register `mul` in codex-rs workspace

## Testing
- `cargo clippy -p codex-mul`
- `cargo test -p codex-mul`


------
https://chatgpt.com/codex/tasks/task_b_68bbf9134bc48329a9a321d694298717