### PR TITLE
feat: add mul adapter and error type

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1176,6 +1176,7 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/codex-rs/mul/Cargo.toml
+++ b/codex-rs/mul/Cargo.toml
@@ -9,3 +9,4 @@ workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "1"

--- a/codex-rs/mul/src/adapter.rs
+++ b/codex-rs/mul/src/adapter.rs
@@ -1,0 +1,16 @@
+use crate::{MulProgram, error::Result, parser, serializer};
+
+/// Adapter for converting to and from [`MulProgram`] JSON representation.
+pub struct MulAdapter;
+
+impl MulAdapter {
+    /// Serialize a [`MulProgram`] into a JSON string.
+    pub fn to_mul(program: &MulProgram) -> Result<String> {
+        serializer::serialize_program(program)
+    }
+
+    /// Parse a JSON string into a [`MulProgram`].
+    pub fn from_mul(input: &str) -> Result<MulProgram> {
+        parser::parse_program(input)
+    }
+}

--- a/codex-rs/mul/src/error.rs
+++ b/codex-rs/mul/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+/// Result type used within the mul crate.
+pub type Result<T> = std::result::Result<T, MulError>;
+
+/// Errors that can occur while working with `MulProgram`s.
+#[derive(Debug, Error)]
+pub enum MulError {
+    /// Error originating from JSON serialization or deserialization.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}

--- a/codex-rs/mul/src/lib.rs
+++ b/codex-rs/mul/src/lib.rs
@@ -1,5 +1,10 @@
+pub mod adapter;
+pub mod error;
 pub mod parser;
 pub mod serializer;
+
+pub use adapter::MulAdapter;
+pub use error::MulError;
 
 use serde::{Deserialize, Serialize};
 

--- a/codex-rs/mul/src/parser.rs
+++ b/codex-rs/mul/src/parser.rs
@@ -1,6 +1,5 @@
-use crate::MulProgram;
-use serde_json::Error;
+use crate::{MulProgram, error::Result};
 
-pub fn parse_program(input: &str) -> Result<MulProgram, Error> {
-    serde_json::from_str(input)
+pub fn parse_program(input: &str) -> Result<MulProgram> {
+    Ok(serde_json::from_str(input)?)
 }

--- a/codex-rs/mul/src/serializer.rs
+++ b/codex-rs/mul/src/serializer.rs
@@ -1,6 +1,5 @@
-use crate::MulProgram;
-use serde_json::Error;
+use crate::{MulProgram, error::Result};
 
-pub fn serialize_program(program: &MulProgram) -> Result<String, Error> {
-    serde_json::to_string(program)
+pub fn serialize_program(program: &MulProgram) -> Result<String> {
+    Ok(serde_json::to_string(program)?)
 }


### PR DESCRIPTION
## Summary
- add `MulAdapter` with `to_mul`/`from_mul`
- introduce `MulError` and use it across parser and serializer
- export adapter and error from library

## Testing
- `cargo test -p codex-mul`


------
https://chatgpt.com/codex/tasks/task_b_68bbfa91e2008329a7701e92398f8763