### PR TITLE
feat: add tooling adapter trait

### DIFF
--- a/codex-rs/mul/src/lib.rs
+++ b/codex-rs/mul/src/lib.rs
@@ -3,9 +3,11 @@ pub mod error;
 pub mod langs;
 pub mod parser;
 pub mod serializer;
+pub mod tooling;
 
 pub use adapter::{JsonAdapter, MulAdapter};
 pub use error::MulError;
+pub use tooling::{ToolAdapter, default::DefaultToolAdapter};
 
 use serde::{Deserialize, Serialize};
 

--- a/codex-rs/mul/src/tooling.rs
+++ b/codex-rs/mul/src/tooling.rs
@@ -1,0 +1,18 @@
+use crate::error::Result;
+
+/// Trait defining tooling operations for a given language.
+pub trait ToolAdapter {
+    /// Build the generated project or source code.
+    fn build() -> Result<()>;
+
+    /// Run tests for the generated project.
+    fn test() -> Result<()>;
+
+    /// Lint the generated source code.
+    fn lint() -> Result<()>;
+
+    /// Execute the generated program.
+    fn run() -> Result<()>;
+}
+
+pub mod default;

--- a/codex-rs/mul/src/tooling/default.rs
+++ b/codex-rs/mul/src/tooling/default.rs
@@ -1,0 +1,45 @@
+use super::ToolAdapter;
+use crate::error::Result;
+
+/// No-op implementation of [`ToolAdapter`].
+pub struct DefaultToolAdapter;
+
+impl ToolAdapter for DefaultToolAdapter {
+    fn build() -> Result<()> {
+        Ok(())
+    }
+
+    fn test() -> Result<()> {
+        Ok(())
+    }
+
+    fn lint() -> Result<()> {
+        Ok(())
+    }
+
+    fn run() -> Result<()> {
+        Ok(())
+    }
+}
+
+impl DefaultToolAdapter {
+    /// Convenience wrapper around [`ToolAdapter::build`].
+    pub fn build() -> Result<()> {
+        <Self as ToolAdapter>::build()
+    }
+
+    /// Convenience wrapper around [`ToolAdapter::test`].
+    pub fn test() -> Result<()> {
+        <Self as ToolAdapter>::test()
+    }
+
+    /// Convenience wrapper around [`ToolAdapter::lint`].
+    pub fn lint() -> Result<()> {
+        <Self as ToolAdapter>::lint()
+    }
+
+    /// Convenience wrapper around [`ToolAdapter::run`].
+    pub fn run() -> Result<()> {
+        <Self as ToolAdapter>::run()
+    }
+}


### PR DESCRIPTION
## Summary
- define ToolAdapter trait for common build, test, lint and run operations
- add default no-op ToolAdapter implementation
- expose tooling module via library exports

## Testing
- `cargo test -p codex-mul`


------
https://chatgpt.com/codex/tasks/task_b_68bc06788f048329a21b4bbc1e6427b4