### PR TITLE
feat: add language tooling adapters

### DIFF
--- a/codex-rs/mul/src/tooling.rs
+++ b/codex-rs/mul/src/tooling.rs
@@ -3,16 +3,49 @@ use crate::error::Result;
 /// Trait defining tooling operations for a given language.
 pub trait ToolAdapter {
     /// Build the generated project or source code.
-    fn build() -> Result<()>;
+    fn build() -> Result<Vec<&'static str>>;
 
     /// Run tests for the generated project.
-    fn test() -> Result<()>;
+    fn test() -> Result<Vec<&'static str>>;
 
     /// Lint the generated source code.
-    fn lint() -> Result<()>;
+    fn lint() -> Result<Vec<&'static str>>;
 
     /// Execute the generated program.
-    fn run() -> Result<()>;
+    fn run() -> Result<Vec<&'static str>>;
 }
 
+pub mod ada;
+pub mod bash;
+pub mod c;
+pub mod clojure;
+pub mod cpp;
+pub mod csharp;
+pub mod dart;
 pub mod default;
+pub mod elixir;
+pub mod erlang;
+pub mod fortran;
+pub mod fsharp;
+pub mod go;
+pub mod groovy;
+pub mod haskell;
+pub mod java;
+pub mod javascript;
+pub mod julia;
+pub mod kotlin;
+pub mod lua;
+pub mod matlab;
+pub mod objectivec;
+pub mod ocaml;
+pub mod perl;
+pub mod php;
+pub mod powershell;
+pub mod python;
+pub mod r;
+pub mod ruby;
+pub mod rust;
+pub mod scala;
+pub mod sql;
+pub mod swift;
+pub mod typescript;

--- a/codex-rs/mul/src/tooling/ada.rs
+++ b/codex-rs/mul/src/tooling/ada.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gnatmake"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gnattest"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gnatpp"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gnat"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/bash.rs
+++ b/codex-rs/mul/src/tooling/bash.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["bash"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["bats"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["shellcheck"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["bash"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/c.rs
+++ b/codex-rs/mul/src/tooling/c.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gcc"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["ctest"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clang-tidy"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["./a.out"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/clojure.rs
+++ b/codex-rs/mul/src/tooling/clojure.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["lein"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["lein"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clj-kondo"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clojure"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/cpp.rs
+++ b/codex-rs/mul/src/tooling/cpp.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["g++"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["ctest"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clang-tidy"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["./a.out"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/csharp.rs
+++ b/codex-rs/mul/src/tooling/csharp.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "format"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/dart.rs
+++ b/codex-rs/mul/src/tooling/dart.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dart", "pub", "get"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dart", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dart", "analyze"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dart", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/elixir.rs
+++ b/codex-rs/mul/src/tooling/elixir.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mix", "compile"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mix", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mix", "format"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mix", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/erlang.rs
+++ b/codex-rs/mul/src/tooling/erlang.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["rebar3", "compile"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["rebar3", "eunit"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["rebar3", "dialyzer"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["erl"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/fortran.rs
+++ b/codex-rs/mul/src/tooling/fortran.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gfortran"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["fpm", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["flint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["./a.out"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/fsharp.rs
+++ b/codex-rs/mul/src/tooling/fsharp.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "fsharplint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dotnet", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/go.rs
+++ b/codex-rs/mul/src/tooling/go.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["go", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["go", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["golangci-lint", "run"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["go", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/groovy.rs
+++ b/codex-rs/mul/src/tooling/groovy.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gradle", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gradle", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["codenarc"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["groovy"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/haskell.rs
+++ b/codex-rs/mul/src/tooling/haskell.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["stack", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["stack", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["hlint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["stack", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/java.rs
+++ b/codex-rs/mul/src/tooling/java.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mvn", "package"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mvn", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["mvn", "checkstyle:check"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["java"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/javascript.rs
+++ b/codex-rs/mul/src/tooling/javascript.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "run", "lint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["node"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/julia.rs
+++ b/codex-rs/mul/src/tooling/julia.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["julia"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["julia"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["julia"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["julia"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/kotlin.rs
+++ b/codex-rs/mul/src/tooling/kotlin.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gradle", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["gradle", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["ktlint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["kotlin"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/lua.rs
+++ b/codex-rs/mul/src/tooling/lua.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["luarocks", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["busted"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["luacheck"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["lua"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/matlab.rs
+++ b/codex-rs/mul/src/tooling/matlab.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["matlab"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["matlab"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["matlab"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["matlab"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/objectivec.rs
+++ b/codex-rs/mul/src/tooling/objectivec.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clang"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["xctest"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["clang-tidy"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["./a.out"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/ocaml.rs
+++ b/codex-rs/mul/src/tooling/ocaml.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dune", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dune", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["ocamlformat"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["dune", "exec"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/perl.rs
+++ b/codex-rs/mul/src/tooling/perl.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["cpanm"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["prove"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["perlcritic"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["perl"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/php.rs
+++ b/codex-rs/mul/src/tooling/php.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["composer", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["phpunit"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["phpcs"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["php"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/powershell.rs
+++ b/codex-rs/mul/src/tooling/powershell.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pwsh"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pester"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pwsh", "-Command", "Invoke-ScriptAnalyzer"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pwsh"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/python.rs
+++ b/codex-rs/mul/src/tooling/python.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pip", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["pytest"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["flake8"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["python"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/r.rs
+++ b/codex-rs/mul/src/tooling/r.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["R", "CMD", "INSTALL"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["R", "-e", "testthat::test_dir('.')"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["lintr"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["Rscript"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/ruby.rs
+++ b/codex-rs/mul/src/tooling/ruby.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["bundle", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["rspec"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["rubocop"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["ruby"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/rust.rs
+++ b/codex-rs/mul/src/tooling/rust.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["cargo", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["cargo", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["cargo", "clippy"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["cargo", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/scala.rs
+++ b/codex-rs/mul/src/tooling/scala.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["sbt", "compile"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["sbt", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["scalafmt"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["sbt", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/sql.rs
+++ b/codex-rs/mul/src/tooling/sql.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["psql"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["psql"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["sqlfluff"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["psql"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/swift.rs
+++ b/codex-rs/mul/src/tooling/swift.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["swift", "build"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["swift", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["swiftlint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["swift", "run"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/src/tooling/typescript.rs
+++ b/codex-rs/mul/src/tooling/typescript.rs
@@ -1,44 +1,33 @@
 use super::ToolAdapter;
 use crate::error::Result;
 
-/// No-op implementation of [`ToolAdapter`].
-pub struct DefaultToolAdapter;
+pub struct Adapter;
 
-impl ToolAdapter for DefaultToolAdapter {
+impl ToolAdapter for Adapter {
     fn build() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "install"])
     }
-
     fn test() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "test"])
     }
-
     fn lint() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["npm", "run", "lint"])
     }
-
     fn run() -> Result<Vec<&'static str>> {
-        Ok(vec![])
+        Ok(vec!["node"])
     }
 }
 
-impl DefaultToolAdapter {
-    /// Convenience wrapper around [`ToolAdapter::build`].
+impl Adapter {
     pub fn build() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::build()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::test`].
     pub fn test() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::test()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::lint`].
     pub fn lint() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::lint()
     }
-
-    /// Convenience wrapper around [`ToolAdapter::run`].
     pub fn run() -> Result<Vec<&'static str>> {
         <Self as ToolAdapter>::run()
     }

--- a/codex-rs/mul/tests/ada_tooling.rs
+++ b/codex-rs/mul/tests/ada_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::ada::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["gnatmake"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["gnattest"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["gnatpp"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["gnat"]);
+}

--- a/codex-rs/mul/tests/bash_tooling.rs
+++ b/codex-rs/mul/tests/bash_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::bash::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["bash"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["bats"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["shellcheck"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["bash"]);
+}

--- a/codex-rs/mul/tests/c_tooling.rs
+++ b/codex-rs/mul/tests/c_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::c::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["gcc"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["ctest"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["clang-tidy"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["./a.out"]);
+}

--- a/codex-rs/mul/tests/clojure_tooling.rs
+++ b/codex-rs/mul/tests/clojure_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::clojure::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["lein"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["lein"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["clj-kondo"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["clojure"]);
+}

--- a/codex-rs/mul/tests/cpp_tooling.rs
+++ b/codex-rs/mul/tests/cpp_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::cpp::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["g++"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["ctest"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["clang-tidy"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["./a.out"]);
+}

--- a/codex-rs/mul/tests/csharp_tooling.rs
+++ b/codex-rs/mul/tests/csharp_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::csharp::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["dotnet", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["dotnet", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["dotnet", "format"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["dotnet", "run"]);
+}

--- a/codex-rs/mul/tests/dart_tooling.rs
+++ b/codex-rs/mul/tests/dart_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::dart::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["dart", "pub", "get"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["dart", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["dart", "analyze"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["dart", "run"]);
+}

--- a/codex-rs/mul/tests/elixir_tooling.rs
+++ b/codex-rs/mul/tests/elixir_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::elixir::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["mix", "compile"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["mix", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["mix", "format"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["mix", "run"]);
+}

--- a/codex-rs/mul/tests/erlang_tooling.rs
+++ b/codex-rs/mul/tests/erlang_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::erlang::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["rebar3", "compile"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["rebar3", "eunit"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["rebar3", "dialyzer"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["erl"]);
+}

--- a/codex-rs/mul/tests/fortran_tooling.rs
+++ b/codex-rs/mul/tests/fortran_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::fortran::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["gfortran"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["fpm", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["flint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["./a.out"]);
+}

--- a/codex-rs/mul/tests/fsharp_tooling.rs
+++ b/codex-rs/mul/tests/fsharp_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::fsharp::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["dotnet", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["dotnet", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["dotnet", "fsharplint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["dotnet", "run"]);
+}

--- a/codex-rs/mul/tests/go_tooling.rs
+++ b/codex-rs/mul/tests/go_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::go::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["go", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["go", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["golangci-lint", "run"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["go", "run"]);
+}

--- a/codex-rs/mul/tests/groovy_tooling.rs
+++ b/codex-rs/mul/tests/groovy_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::groovy::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["gradle", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["gradle", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["codenarc"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["groovy"]);
+}

--- a/codex-rs/mul/tests/haskell_tooling.rs
+++ b/codex-rs/mul/tests/haskell_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::haskell::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["stack", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["stack", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["hlint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["stack", "run"]);
+}

--- a/codex-rs/mul/tests/java_tooling.rs
+++ b/codex-rs/mul/tests/java_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::java::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["mvn", "package"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["mvn", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["mvn", "checkstyle:check"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["java"]);
+}

--- a/codex-rs/mul/tests/javascript_tooling.rs
+++ b/codex-rs/mul/tests/javascript_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::javascript::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["npm", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["npm", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["npm", "run", "lint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["node"]);
+}

--- a/codex-rs/mul/tests/julia_tooling.rs
+++ b/codex-rs/mul/tests/julia_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::julia::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["julia"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["julia"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["julia"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["julia"]);
+}

--- a/codex-rs/mul/tests/kotlin_tooling.rs
+++ b/codex-rs/mul/tests/kotlin_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::kotlin::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["gradle", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["gradle", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["ktlint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["kotlin"]);
+}

--- a/codex-rs/mul/tests/lua_tooling.rs
+++ b/codex-rs/mul/tests/lua_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::lua::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["luarocks", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["busted"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["luacheck"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["lua"]);
+}

--- a/codex-rs/mul/tests/matlab_tooling.rs
+++ b/codex-rs/mul/tests/matlab_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::matlab::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["matlab"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["matlab"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["matlab"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["matlab"]);
+}

--- a/codex-rs/mul/tests/objectivec_tooling.rs
+++ b/codex-rs/mul/tests/objectivec_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::objectivec::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["clang"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["xctest"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["clang-tidy"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["./a.out"]);
+}

--- a/codex-rs/mul/tests/ocaml_tooling.rs
+++ b/codex-rs/mul/tests/ocaml_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::ocaml::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["dune", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["dune", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["ocamlformat"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["dune", "exec"]);
+}

--- a/codex-rs/mul/tests/perl_tooling.rs
+++ b/codex-rs/mul/tests/perl_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::perl::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["cpanm"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["prove"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["perlcritic"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["perl"]);
+}

--- a/codex-rs/mul/tests/php_tooling.rs
+++ b/codex-rs/mul/tests/php_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::php::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["composer", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["phpunit"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["phpcs"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["php"]);
+}

--- a/codex-rs/mul/tests/powershell_tooling.rs
+++ b/codex-rs/mul/tests/powershell_tooling.rs
@@ -1,0 +1,12 @@
+use codex_mul::tooling::powershell::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["pwsh"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["pester"]);
+    assert_eq!(
+        Adapter::lint().unwrap(),
+        vec!["pwsh", "-Command", "Invoke-ScriptAnalyzer"]
+    );
+    assert_eq!(Adapter::run().unwrap(), vec!["pwsh"]);
+}

--- a/codex-rs/mul/tests/python_tooling.rs
+++ b/codex-rs/mul/tests/python_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::python::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["pip", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["pytest"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["flake8"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["python"]);
+}

--- a/codex-rs/mul/tests/r_tooling.rs
+++ b/codex-rs/mul/tests/r_tooling.rs
@@ -1,0 +1,12 @@
+use codex_mul::tooling::r::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["R", "CMD", "INSTALL"]);
+    assert_eq!(
+        Adapter::test().unwrap(),
+        vec!["R", "-e", "testthat::test_dir('.')"]
+    );
+    assert_eq!(Adapter::lint().unwrap(), vec!["lintr"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["Rscript"]);
+}

--- a/codex-rs/mul/tests/ruby_tooling.rs
+++ b/codex-rs/mul/tests/ruby_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::ruby::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["bundle", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["rspec"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["rubocop"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["ruby"]);
+}

--- a/codex-rs/mul/tests/rust_tooling.rs
+++ b/codex-rs/mul/tests/rust_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::rust::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["cargo", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["cargo", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["cargo", "clippy"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["cargo", "run"]);
+}

--- a/codex-rs/mul/tests/scala_tooling.rs
+++ b/codex-rs/mul/tests/scala_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::scala::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["sbt", "compile"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["sbt", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["scalafmt"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["sbt", "run"]);
+}

--- a/codex-rs/mul/tests/sql_tooling.rs
+++ b/codex-rs/mul/tests/sql_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::sql::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["psql"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["psql"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["sqlfluff"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["psql"]);
+}

--- a/codex-rs/mul/tests/swift_tooling.rs
+++ b/codex-rs/mul/tests/swift_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::swift::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["swift", "build"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["swift", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["swiftlint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["swift", "run"]);
+}

--- a/codex-rs/mul/tests/typescript_tooling.rs
+++ b/codex-rs/mul/tests/typescript_tooling.rs
@@ -1,0 +1,9 @@
+use codex_mul::tooling::typescript::Adapter;
+
+#[test]
+fn commands() {
+    assert_eq!(Adapter::build().unwrap(), vec!["npm", "install"]);
+    assert_eq!(Adapter::test().unwrap(), vec!["npm", "test"]);
+    assert_eq!(Adapter::lint().unwrap(), vec!["npm", "run", "lint"]);
+    assert_eq!(Adapter::run().unwrap(), vec!["node"]);
+}


### PR DESCRIPTION
## Summary
- add `ToolAdapter` trait returning command vectors
- implement tooling modules for each language and map to common build/test/lint/run tools
- add integration tests validating generated commands per language

## Testing
- `cargo fmt --all`
- `cargo test -p codex-mul`

------
https://chatgpt.com/codex/tasks/task_b_68bc1dfde22083298154115679a3de7e