### PR TITLE
feat(core): add default language and toolchain config

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -14,9 +14,9 @@ use crate::config_types::Tui;
 use crate::config_types::UriBasedFileOpener;
 use crate::config_types::Verbosity;
 use crate::git_info::resolve_root_git_project_for_trust;
-use crate::model_family::{ModelFamily, built_in_model_capabilities, find_family_for_model};
-use crate::model_provider_info::ModelProviderInfo;
+use crate::model_family::{built_in_model_capabilities, find_family_for_model, ModelFamily};
 use crate::model_provider_info::built_in_model_providers;
+use crate::model_provider_info::ModelProviderInfo;
 use crate::openai_model_info::get_model_info;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
@@ -168,6 +168,12 @@ pub struct Config {
     ///
     /// When this program is invoked, arg0 will be set to `codex-linux-sandbox`.
     pub codex_linux_sandbox_exe: Option<PathBuf>,
+
+    /// Default programming language used when none is specified.
+    pub default_language: Option<String>,
+
+    /// Default toolchain or version associated with `default_language`.
+    pub default_toolchain: Option<String>,
 
     /// Value to use for `reasoning.effort` when making a request using the
     /// Responses API.
@@ -509,6 +515,12 @@ pub struct ConfigToml {
 
     /// Collection of settings that are specific to the TUI.
     pub tui: Option<Tui>,
+
+    /// Default programming language used when none is specified.
+    pub default_language: Option<String>,
+
+    /// Default toolchain or runtime version for `default_language`.
+    pub default_toolchain: Option<String>,
 
     /// When set to `true`, `AgentReasoning` events will be hidden from the
     /// UI/output. Defaults to `false`.
@@ -1012,6 +1024,8 @@ impl Config {
             file_opener: cfg.file_opener.unwrap_or(UriBasedFileOpener::VsCode),
             tui: tui_cfg,
             codex_linux_sandbox_exe,
+            default_language: cfg.default_language,
+            default_toolchain: cfg.default_toolchain,
 
             hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
             show_raw_agent_reasoning: cfg
@@ -1412,6 +1426,8 @@ disable_response_storage = true
                 file_opener: UriBasedFileOpener::VsCode,
                 tui: Tui::default(),
                 codex_linux_sandbox_exe: None,
+                default_language: None,
+                default_toolchain: None,
                 hide_agent_reasoning: false,
                 show_raw_agent_reasoning: false,
                 model_reasoning_effort: ReasoningEffort::High,
@@ -1475,6 +1491,8 @@ disable_response_storage = true
             file_opener: UriBasedFileOpener::VsCode,
             tui: Tui::default(),
             codex_linux_sandbox_exe: None,
+            default_language: None,
+            default_toolchain: None,
             hide_agent_reasoning: false,
             show_raw_agent_reasoning: false,
             model_reasoning_effort: ReasoningEffort::default(),
@@ -1553,6 +1571,8 @@ disable_response_storage = true
             file_opener: UriBasedFileOpener::VsCode,
             tui: Tui::default(),
             codex_linux_sandbox_exe: None,
+            default_language: None,
+            default_toolchain: None,
             hide_agent_reasoning: false,
             show_raw_agent_reasoning: false,
             model_reasoning_effort: ReasoningEffort::default(),

--- a/docs/config.md
+++ b/docs/config.md
@@ -67,6 +67,28 @@ The model that Codex should use.
 model = "o3"  # overrides the default of "gpt-5"
 ```
 
+## default_language and default_toolchain
+
+These settings establish the language Codex should assume when generating
+code and the associated toolchain or runtime version to use. They are
+optional and default to using the model's best guess.
+
+Examples:
+
+```toml
+# Rust using the stable toolchain
+default_language = "rust"
+default_toolchain = "stable"
+
+# Python 3.11
+default_language = "python"
+default_toolchain = "3.11"
+
+# JavaScript via Node.js 20
+default_language = "javascript"
+default_toolchain = "node-20"
+```
+
 ## model_providers
 
 This option lets you override and amend the default set of model providers bundled with Codex. This value is a map where the key is the value to use with `model_provider` to select the corresponding provider.
@@ -773,6 +795,8 @@ auto_compact_tolerance_percent = 8
 | `stream_idle_timeout_ms`                         | number             | Global default SSE idle timeout (ms) applied to selected provider.                         |
 | `project_doc_max_bytes`                          | number             | Max bytes to read from `AGENTS.md`.                                                        |
 | `command_timeout_ms`                             | number or `"none"` | Default host command timeout in ms or disable with `"none"`.                               |
+| `default_language`                              | string             | Preferred programming language for generated code.                     |
+| `default_toolchain`                             | string             | Toolchain or runtime version associated with `default_language`.       |
 | `profile`                                        | string             | Active profile name.                                                                       |
 | `profiles.<name>.*`                              | various            | Profile‑scoped overrides of the same keys.                                                 |
 | `history.persistence`                            | `save-all`         | `none`                                                                                     | History file persistence (default: `save-all`).  |


### PR DESCRIPTION
## Summary
- allow specifying `default_language` and `default_toolchain` in configuration
- document new options with sample entries for Rust, Python, and JavaScript

## Testing
- `cargo fmt -- codex-rs/core/src/config.rs`
- `cargo test -p codex-core --manifest-path codex-rs/Cargo.toml` *(fails: mismatched closing delimiter in agents/builtin.rs)*

------
https://chatgpt.com/codex/tasks/task_b_68bc85c752888329b9dc9bef86493a35