### PR TITLE
docs: add MUL overview and adapter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
   - [Non-interactive / CI mode](./docs/advanced.md#non-interactive--ci-mode)
   - [Tracing / verbose logging](./docs/advanced.md#tracing--verbose-logging)
   - [Model Context Protocol (MCP)](./docs/advanced.md#model-context-protocol-mcp)
+- [**MUL concepts**](./docs/mul.md)
 - [**Zero data retention (ZDR)**](./docs/zdr.md)
 - [**Server & API**](./docs/server.md)
 - [**Contributing**](./docs/contributing.md)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,5 +1,7 @@
 ## Advanced
 
+Codex's cross-language features rely on a typed intermediate representation called MUL. See [MUL concepts](./mul.md) for an overview.
+
 ## Non-interactive / CI mode
 
 Run Codex head-less in pipelines. Example GitHub Action step:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -14,6 +14,13 @@ If you want to add a new feature or change the behavior of an existing one, plea
 - Keep your changes focused. Multiple unrelated fixes should be opened as separate PRs.
 - Following the [development setup](#development-workflow) instructions above, ensure your change is free of lint warnings and test failures.
 
+### Adding language or tooling adapters
+
+- Open an issue to discuss the new adapter and get maintainer approval before starting work.
+- Implement the adapter (e.g. a `MulAdapter` for a new language or an analysis backend) with tests demonstrating round-trip conversions.
+- Update examples and `docs/mul.md` to list the new language or tooling.
+- Run the full test suite and include documentation for any new commands or configuration.
+
 ### Writing high-impact code changes
 
 1. **Start with an issue.** Open a new one or comment on an existing discussion so we can agree on the solution before code is written.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 ## Getting started
 
+Codex translates between languages using a small intermediate representation called MUL. See [MUL concepts](./mul.md) for supported languages and tooling adapters.
+
 ### CLI usage
 
 | Command            | Purpose                            | Example                         |

--- a/docs/mul.md
+++ b/docs/mul.md
@@ -1,0 +1,27 @@
+## MUL
+
+MUL is a small, typed language that Codex uses as an intermediate representation. Programs are expressed with modules, functions, structs, and explicit types, letting Codex translate code across ecosystems and perform deeper analysis.
+
+For the full grammar and AST description see the [MUL specification](./mul-spec.md).
+
+### Supported languages
+
+Codex currently ships adapters that convert between MUL and:
+
+- Python
+- JavaScript
+- Rust
+- Go
+
+Use `codex mul --from <language> --to <language>` to translate between these targets.
+
+### Tooling adapters
+
+Language support and analysis capabilities are implemented through adapters in the `codex-rs/mul` crate. Adapters implement the `MulAdapter` trait to convert source code to and from the `MulProgram` representation. Additional tooling layers build on top of this, including:
+
+- **Parser** – turns source text into a typed AST.
+- **Code generator** – emits source from a `MulProgram`.
+- **Analyzer** – walks the AST/IR to compute metrics or surface diagnostics.
+- **Refactor engine** – applies structural edits and pretty‑prints the result.
+
+These components enable consistent cross‑language transformations and can be extended with new adapters for additional languages or tooling backends.


### PR DESCRIPTION
## Summary
- document MUL concepts, supported languages, and tooling adapters
- link MUL docs from README and other guides
- add contribution steps for new language/tooling adapters

## Testing
- `cargo test -p codex-core` *(fails: unresolved import `crate::web`)*


------
https://chatgpt.com/codex/tasks/task_b_68bcf5c0c92c83299dd6bd8e1475d766