### PR TITLE
feat: add MUL client support and bundle scripts

### DIFF
--- a/clients/dart/README.md
+++ b/clients/dart/README.md
@@ -1,3 +1,15 @@
 # Dart Client
 
-Reserved for future development.
+Minimal Dart wrapper for the Codex HTTP API.
+
+```dart
+import 'package:codex_client/codex_client.dart';
+
+void main() async {
+  final client = CodexClient('http://localhost:8080');
+  final out = await client.mul('module main {}', 'mul', 'rust');
+  print(out);
+}
+```
+
+`mul` translates source text using named adapters.

--- a/clients/dart/lib/codex_client.dart
+++ b/clients/dart/lib/codex_client.dart
@@ -165,4 +165,9 @@ class CodexClient {
       (json) => RagReply.fromJson(json as Map<String, dynamic>),
     );
   }
+
+  Future<String> mul(String source, String from, String to) {
+    final payload = {'source': source, 'from': from, 'to': to};
+    return _post('/v1/mul', payload, (json) => json['output'] as String);
+  }
 }

--- a/clients/dart/test/codex_client_test.dart
+++ b/clients/dart/test/codex_client_test.dart
@@ -88,5 +88,19 @@ void main() {
       expect(reply.answer, '42');
       expect(reply.references.length, 1);
     });
+
+    test('mul', () async {
+      final mock = MockClient((request) async {
+        expect(request.url.path, '/v1/mul');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['source'], '1');
+        expect(body['from'], 'mul');
+        expect(body['to'], 'rust');
+        return http.Response(jsonEncode({'output': 'translated'}), 200);
+      });
+      final client = CodexClient('http://x', httpClient: mock);
+      final out = await client.mul('1', 'mul', 'rust');
+      expect(out, 'translated');
+    });
   });
 }

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -1,3 +1,22 @@
 # Go Client
 
-Reserved for future development.
+Minimal helper for calling the Codex HTTP API from Go.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    codex "github.com/openai/codex/clients/go"
+)
+
+func main() {
+    c := codex.NewClient("http://localhost:8080")
+    out, _ := c.Mul(context.Background(), "module main {}", "mul", "rust")
+    fmt.Println(out)
+}
+```
+
+The `Mul` method accepts source text along with `from` and `to` adapter names and
+returns the translated source.

--- a/clients/go/client.go
+++ b/clients/go/client.go
@@ -46,6 +46,13 @@ type VectorRecord struct {
 	Document string    `json:"document"`
 }
 
+// MulRequest represents a request to translate source code using MUL adapters.
+type MulRequest struct {
+	Source string `json:"source"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+}
+
 func (c *Client) do(ctx context.Context, method, path string, reqBody, respBody interface{}) error {
 	var body io.Reader
 	if reqBody != nil {
@@ -166,4 +173,16 @@ func (c *Client) RAGAnswer(ctx context.Context, question string, topK int, tier 
 		refs[i] = Reference{Document: doc}
 	}
 	return Result{Answer: resp.Answer, References: refs}, nil
+}
+
+// Mul translates source code between languages using MUL adapters.
+func (c *Client) Mul(ctx context.Context, source, fromAdapter, toAdapter string) (string, error) {
+	req := MulRequest{Source: source, From: fromAdapter, To: toAdapter}
+	var resp struct {
+		Output string `json:"output"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/v1/mul", &req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Output, nil
 }

--- a/clients/go/client_test.go
+++ b/clients/go/client_test.go
@@ -123,6 +123,31 @@ func TestRAGAnswer(t *testing.T) {
 	}
 }
 
+func TestMul(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mul" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var req MulRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if req.Source != "1" || req.From != "mul" || req.To != "rust" {
+			t.Fatalf("bad request: %+v", req)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"output": "translated"})
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL)
+	out, err := c.Mul(context.Background(), "1", "mul", "rust")
+	if err != nil {
+		t.Fatalf("Mul: %v", err)
+	}
+	if out != "translated" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
 func ExampleClient_Chat() {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"reply": "hello"})

--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -2,7 +2,8 @@
 
 Run the following:
 
-To build the 0.2.x or later version of the npm module, which runs the Rust version of the CLI, build it as follows:
+To build the 0.2.x or later version of the npm module, which runs the Rust version of the CLI, build it as follows. The staging
+process now bundles the `codex-mul` crate so the published package supports the `mul` subcommand (`--from`/`--to` flags):
 
 ```bash
 ./codex-cli/scripts/stage_rust_release.py --release-version 0.6.0

--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -75,17 +75,38 @@ gh run download --dir "$ARTIFACTS_DIR" --repo openai/codex "$WORKFLOW_ID"
 # x64 Linux
 zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-x86_64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-x86_64-unknown-linux-musl"
+# Optionally include the MUL translation helper if available.
+if [[ -f "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-mul-x86_64-unknown-linux-musl.zst" ]]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-mul-x86_64-unknown-linux-musl.zst" \
+    -o "$BIN_DIR/codex-mul-x86_64-unknown-linux-musl"
+fi
 # ARM64 Linux
 zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-aarch64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-aarch64-unknown-linux-musl"
+if [[ -f "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-mul-aarch64-unknown-linux-musl.zst" ]]; then
+  zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-mul-aarch64-unknown-linux-musl.zst" \
+    -o "$BIN_DIR/codex-mul-aarch64-unknown-linux-musl"
+fi
 # x64 macOS
 zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-x86_64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-x86_64-apple-darwin"
+if [[ -f "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-mul-x86_64-apple-darwin.zst" ]]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-mul-x86_64-apple-darwin.zst" \
+    -o "$BIN_DIR/codex-mul-x86_64-apple-darwin"
+fi
 # ARM64 macOS
 zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/codex-aarch64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-aarch64-apple-darwin"
+if [[ -f "$ARTIFACTS_DIR/aarch64-apple-darwin/codex-mul-aarch64-apple-darwin.zst" ]]; then
+  zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/codex-mul-aarch64-apple-darwin.zst" \
+    -o "$BIN_DIR/codex-mul-aarch64-apple-darwin"
+fi
 # x64 Windows
 zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe.zst" \
     -o "$BIN_DIR/codex-x86_64-pc-windows-msvc.exe"
+if [[ -f "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/codex-mul-x86_64-pc-windows-msvc.exe.zst" ]]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/codex-mul-x86_64-pc-windows-msvc.exe.zst" \
+    -o "$BIN_DIR/codex-mul-x86_64-pc-windows-msvc.exe"
+fi
 
 echo "Installed native dependencies into $BIN_DIR"

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -115,6 +115,7 @@ echo "Staged version $VERSION for release in $TMPDIR"
 echo "Verify the CLI:"
 echo "    node ${TMPDIR}/bin/codex.js --version"
 echo "    node ${TMPDIR}/bin/codex.js --help"
+echo "    echo 'module main { fn add(a:Int,b:Int)->Int{a+b;} }' | node ${TMPDIR}/bin/codex.js mul --from mul --to rust"
 
 # Print final hint for convenience
 echo "Next:  cd \"$TMPDIR\" && npm publish"


### PR DESCRIPTION
## Summary
- bundle `codex-mul` artifacts during CLI release staging
- add `Mul` API for Go and Dart clients with adapter selection
- document client usage and MUL translation examples

## Testing
- `pnpm -C codex-cli install`
- `pnpm -C codex-cli run build` *(fails: Missing script: build)*
- `go test ./clients/go`
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_b_68bcf7ea53608329b073ed6e1bf9ee7d