### PR TITLE
feat(core): add provider tool support metadata

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -89,7 +89,13 @@ impl ModelClient {
         conversation_id: ConversationId,
     ) -> Self {
         let client = create_client();
-        let tool_bridge = provider.tool_bridge.as_deref().and_then(create_tool_bridge);
+        let mut tool_bridge = provider.tool_bridge.as_deref().and_then(create_tool_bridge);
+        if tool_bridge.is_none() {
+            let is_ollama = provider.name.to_ascii_lowercase().contains("ollama");
+            if is_ollama && !provider.supports_tools {
+                tool_bridge = create_tool_bridge("ollama");
+            }
+        }
 
         Self {
             config,
@@ -850,6 +856,7 @@ mod tests {
             stream_idle_timeout_ms: Some(1000),
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -912,6 +919,7 @@ mod tests {
             stream_idle_timeout_ms: Some(1000),
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -948,6 +956,7 @@ mod tests {
             stream_idle_timeout_ms: Some(1000),
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -1055,6 +1064,7 @@ mod tests {
                 stream_idle_timeout_ms: Some(1000),
                 model_family: None,
                 tool_bridge: None,
+                supports_tools: true,
                 requires_openai_auth: false,
             };
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1416,6 +1416,7 @@ model_verbosity = "high"
             stream_idle_timeout_ms: Some(300_000),
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
         let model_provider_map = {

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -90,12 +90,21 @@ pub struct ModelProviderInfo {
     #[serde(default)]
     pub tool_bridge: Option<String>,
 
+    /// Whether the provider natively supports tool usage without additional
+    /// bridging. Defaults to `true` for backwards compatibility.
+    #[serde(default = "default_supports_tools")]
+    pub supports_tools: bool,
+
     /// Does this provider require an OpenAI API Key or ChatGPT login token? If true,
     /// user is presented with login screen on first run, and login preference and token/key
     /// are stored in auth.json. If false (which is the default), login screen is skipped,
     /// and API key (if needed) comes from the "env_key" environment variable.
     #[serde(default)]
     pub requires_openai_auth: bool,
+}
+
+fn default_supports_tools() -> bool {
+    true
 }
 
 impl ModelProviderInfo {
@@ -293,6 +302,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 stream_idle_timeout_ms: None,
                 model_family: None,
                 tool_bridge: None,
+                supports_tools: true,
                 requires_openai_auth: true,
             },
         ),
@@ -352,6 +362,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
         stream_idle_timeout_ms: None,
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     }
 }
@@ -370,7 +381,8 @@ fn create_ollama_provider(name: &str, model_family: Option<&str>) -> ModelProvid
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
         model_family: model_family.map(|s| s.to_string()),
-        tool_bridge: Some("ollama".to_string()),
+        tool_bridge: None,
+        supports_tools: false,
         requires_openai_auth: false,
     }
 }
@@ -400,6 +412,7 @@ base_url = "http://localhost:11434/v1"
             stream_idle_timeout_ms: None,
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -431,6 +444,7 @@ query_params = { api-version = "2025-04-01-preview" }
             stream_idle_timeout_ms: None,
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -465,6 +479,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             stream_idle_timeout_ms: None,
             model_family: None,
             tool_bridge: None,
+            supports_tools: true,
             requires_openai_auth: false,
         };
 
@@ -488,5 +503,6 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             providers["ollama-cogito"].model_family.as_deref(),
             Some("cogito"),
         );
+        assert!(!providers["ollama"].supports_tools);
     }
 }

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -57,6 +57,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         stream_idle_timeout_ms: Some(5_000),
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -50,6 +50,7 @@ async fn run_stream(sse_body: &str) -> Vec<ResponseEvent> {
         stream_idle_timeout_ms: Some(5_000),
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -680,6 +680,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
         stream_idle_timeout_ms: None,
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 
@@ -758,6 +759,7 @@ async fn env_var_overrides_loaded_auth() {
         stream_idle_timeout_ms: None,
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -82,6 +82,7 @@ async fn continue_after_stream_error() {
         stream_idle_timeout_ms: Some(2_000),
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -89,6 +89,7 @@ async fn retries_on_early_close() {
         stream_idle_timeout_ms: Some(2000),
         model_family: None,
         tool_bridge: None,
+        supports_tools: true,
         requires_openai_auth: false,
     };
 


### PR DESCRIPTION
## Summary
- track whether a model provider supports tools
- auto-attach Ollama tool bridge when provider lacks tool support

## Testing
- `USER=testuser cargo test -p codex-core`
- `USER=testuser cargo test --all-features` *(fails: python exited with ExitStatus(unix_wait_status(25856)))*

------
https://chatgpt.com/codex/tasks/task_b_68c5e8fbd4a4832fac26d665ab00c945