### PR TITLE
Add force_json_bridge config option

### DIFF
--- a/.github/codex/home/config.toml
+++ b/.github/codex/home/config.toml
@@ -1,3 +1,4 @@
 model = "gpt-5"
+force_json_bridge = false
 
 # Consider setting [mcp_servers] here!

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -132,7 +132,7 @@ impl ModelClient {
     pub async fn stream(&self, prompt: &Prompt) -> Result<ResponseStream> {
         let mut prompt = prompt.clone();
 
-        let bridge = if self.provider.force_json_bridge {
+        let bridge = if self.config.force_json_bridge || self.provider.force_json_bridge {
             self.tool_bridge.clone().or_else(|| {
                 if self
                     .config

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -170,6 +170,10 @@ pub struct Config {
     /// model family's default preference.
     pub include_apply_patch_tool: bool,
 
+    /// Force routing prompts through a JSON tool bridge even when the provider
+    /// advertises native tool support.
+    pub force_json_bridge: bool,
+
     pub tools_web_search_request: bool,
 
     pub use_experimental_streamable_shell_tool: bool,
@@ -589,6 +593,10 @@ pub struct ConfigToml {
     /// Defaults to `false`.
     pub show_raw_agent_reasoning: Option<bool>,
 
+    /// Force routing prompts through a JSON tool bridge even when the provider
+    /// supports tools natively.
+    pub force_json_bridge: Option<bool>,
+
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
@@ -759,6 +767,7 @@ pub struct ConfigOverrides {
     pub include_apply_patch_tool: Option<bool>,
     pub include_view_image_tool: Option<bool>,
     pub show_raw_agent_reasoning: Option<bool>,
+    pub force_json_bridge: Option<bool>,
     pub tools_web_search_request: Option<bool>,
     pub session_logging: Option<bool>,
 }
@@ -787,6 +796,7 @@ impl Config {
             include_apply_patch_tool,
             include_view_image_tool,
             show_raw_agent_reasoning,
+            force_json_bridge: override_force_json_bridge,
             tools_web_search_request: override_tools_web_search_request,
             session_logging: override_session_logging,
         } = overrides;
@@ -865,6 +875,10 @@ impl Config {
         let include_view_image_tool = include_view_image_tool
             .or(cfg.tools.as_ref().and_then(|t| t.view_image))
             .unwrap_or(true);
+
+        let force_json_bridge = override_force_json_bridge
+            .or(cfg.force_json_bridge)
+            .unwrap_or(false);
 
         let model = model
             .or(config_profile.model)
@@ -979,6 +993,7 @@ impl Config {
             experimental_resume,
             include_plan_tool: include_plan_tool.unwrap_or(false),
             include_apply_patch_tool: include_apply_patch_tool.unwrap_or(false),
+            force_json_bridge,
             tools_web_search_request,
             use_experimental_streamable_shell_tool: cfg
                 .experimental_use_exec_command_tool
@@ -1503,6 +1518,7 @@ model_verbosity = "high"
                 base_instructions: None,
                 include_plan_tool: false,
                 include_apply_patch_tool: false,
+                force_json_bridge: false,
                 tools_web_search_request: false,
                 use_experimental_streamable_shell_tool: false,
                 use_experimental_unified_exec_tool: false,
@@ -1561,6 +1577,7 @@ model_verbosity = "high"
             base_instructions: None,
             include_plan_tool: false,
             include_apply_patch_tool: false,
+            force_json_bridge: false,
             tools_web_search_request: false,
             use_experimental_streamable_shell_tool: false,
             use_experimental_unified_exec_tool: false,
@@ -1634,6 +1651,7 @@ model_verbosity = "high"
             base_instructions: None,
             include_plan_tool: false,
             include_apply_patch_tool: false,
+            force_json_bridge: false,
             tools_web_search_request: false,
             use_experimental_streamable_shell_tool: false,
             use_experimental_unified_exec_tool: false,
@@ -1693,6 +1711,7 @@ model_verbosity = "high"
             base_instructions: None,
             include_plan_tool: false,
             include_apply_patch_tool: false,
+            force_json_bridge: false,
             tools_web_search_request: false,
             use_experimental_streamable_shell_tool: false,
             use_experimental_unified_exec_tool: false,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -150,6 +150,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         include_apply_patch_tool: None,
         include_view_image_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
+        force_json_bridge: None,
         tools_web_search_request: None,
         session_logging: None,
     };

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -1259,6 +1259,7 @@ fn derive_config_from_params(
         include_apply_patch_tool,
         include_view_image_tool: None,
         show_raw_agent_reasoning: None,
+        force_json_bridge: None,
         tools_web_search_request: None,
         session_logging: None,
     };

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -163,6 +163,7 @@ impl CodexToolCallParam {
             include_apply_patch_tool: None,
             include_view_image_tool: None,
             show_raw_agent_reasoning: None,
+            force_json_bridge: None,
             tools_web_search_request: None,
             session_logging: None,
         };

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -133,6 +133,7 @@ pub async fn run_main(
         include_apply_patch_tool: None,
         include_view_image_tool: None,
         show_raw_agent_reasoning: cli.oss.then_some(true),
+        force_json_bridge: None,
         tools_web_search_request: cli.web_search.then_some(true),
         session_logging: None,
     };

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -124,6 +124,6 @@ Bridges are pluggable. To add support for another provider:
    custom `wrap_prompt` and `parse_event` logic.
 2. Register it via `register_tooling_bridge("provider-id", || ...)`.
 3. In `config.toml`, set `model_providers.<id>.tool_bridge = "provider-id"` or
-   enable `force_json_tool_bridge` to use the JSON bridge globally.
+   enable `force_json_bridge` to use the JSON bridge globally.
 
 See the Ollama bridge (`codex-rs/ollama`) for a reference implementation.

--- a/docs/config.md
+++ b/docs/config.md
@@ -573,7 +573,7 @@ Example:
 show_raw_agent_reasoning = true  # defaults to false
 ```
 
-## force_json_tool_bridge
+## force_json_bridge
 
 For models that only return plain text, Codex can force a JSON‑based tool
 bridge. When enabled, Codex injects a system message instructing the model to
@@ -585,7 +585,7 @@ assistant message. This is useful for providers like
 model = "llama3.1"
 model_provider = "ollama"
 
-force_json_tool_bridge = true
+force_json_bridge = true
 ```
 
 See the [Advanced guide](./advanced.md#json-tool-bridge) for details on the
@@ -655,7 +655,7 @@ Options that are specific to the TUI.
 | `tui`                                            | table                                                             | TUI‑specific options (reserved).                                                                                                    |
 | `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                                        |
 | `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                                |
-| `force_json_tool_bridge`                         | boolean                                                           | Force JSON tool bridge even if provider supports tools.                                                                             |
+| `force_json_bridge`                              | boolean                                                           | Force JSON tool bridge even if provider supports tools.                                                                             |
 | `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                                     |
 | `model_reasoning_summary`                        | `auto` \| `concise` \| `detailed` \| `none`                       | Reasoning summaries.                                                                                                                |
 | `model_verbosity`                                | `low` \| `medium` \| `high`                                       | GPT‑5 text verbosity (Responses API).                                                                                               |


### PR DESCRIPTION
## Summary
- allow forcing the JSON tooling bridge via `force_json_bridge`
- document `force_json_bridge` and show Ollama examples
- wire new option through CLI config and defaults

## Testing
- `just fix -p codex-core`
- `cargo test -p codex-core`
- `cargo test --all-features` *(fails: sandbox limitation `Suite::sandbox::python_multiprocessing_lock_works_under_sandbox`)*

------
https://chatgpt.com/codex/tasks/task_b_68c72ee518c0832fb79c40b3e1e1dd16