### PR TITLE
Add JSON bridge instructions

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -126,6 +126,10 @@ impl ModelClient {
         })
     }
 
+    pub fn force_json_bridge(&self) -> bool {
+        self.config.force_json_bridge || self.provider.force_json_bridge
+    }
+
     /// Dispatches to either the Responses or Chat implementation depending on
     /// the provider config.  Public callers always invoke `stream()` – the
     /// specialised helpers are private to avoid accidental misuse.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1721,6 +1721,7 @@ async fn run_turn(
         input,
         tools,
         base_instructions_override: turn_context.base_instructions.clone(),
+        force_json_bridge: turn_context.client.force_json_bridge(),
     };
 
     let mut retries = 0;

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -115,6 +115,7 @@ async fn run_compact_task_inner(
         input: turn_input,
         tools: Vec::new(),
         base_instructions_override: Some(instructions_override),
+        force_json_bridge: turn_context.client.force_json_bridge(),
     };
 
     let max_retries = turn_context.client.get_provider().stream_max_retries();

--- a/codex-rs/core/templates/ollama_bridge.md
+++ b/codex-rs/core/templates/ollama_bridge.md
@@ -1,0 +1,7 @@
+Respond only with a single JSON object matching this schema:
+{schema}
+
+- For normal assistant messages, set "type" to "message" and include "content".
+- For tool calls, set "type" to "tool" and include "name" and "input".
+Return only the JSON object with no additional text or markdown. The JSON must be valid and conform exactly to the schema.
+


### PR DESCRIPTION
## Summary
- add ollama_bridge template describing JSON bridge schema
- append JSON bridge instructions when force_json_bridge is enabled
- expose force_json_bridge on client and propagate to prompts

## Testing
- `just fix -p codex-core`
- `cargo test -p codex-core`
- `cargo test --all-features` *(fails: error running landlock: Sandbox(LandlockRestrict))*

------
https://chatgpt.com/codex/tasks/task_b_68c74781e0ac832f997ad9555a1a5347