### PR TITLE
feat(ollama): stream-parse with validation

### DIFF
--- a/codex-rs/ollama/src/lib.rs
+++ b/codex-rs/ollama/src/lib.rs
@@ -5,7 +5,7 @@ mod parser;
 mod pull;
 mod url;
 
-pub use backend::OllamaBackend;
+pub use backend::{ChatStreamEvent, OllamaBackend};
 pub use bridge::OllamaToolBridge;
 pub use bridge::register_ollama_tool_bridge;
 pub use client::OllamaClient;


### PR DESCRIPTION
## Summary
- add `ChatStreamEvent` for streaming responses and errors
- parse streamed JSON chunks, validating each via bridge
- stop streaming and report structured error on invalid JSON

## Testing
- `cargo fmt`
- `just fix -p codex-ollama` *(fails: command not found)*
- `cargo clippy -p codex-ollama --fix --allow-dirty --allow-staged` *(terminated)*
- `cargo test -p codex-ollama` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_b_68c8327eaec4832f9a205a5ff920b3ff