### PR TITLE
Handle legacy apply_patch arguments from LM Studio

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -690,8 +690,7 @@ mod tests {
         assert!(!call_id.is_empty(), "call_id should not be empty");
         assert!(
             call_id.starts_with("tool_call_"),
-            "unexpected fallback call_id prefix: {}",
-            call_id
+            "unexpected fallback call_id prefix: {call_id}"
         );
     }
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2398,8 +2398,13 @@ async fn handle_function_call(
                     "failed to parse function arguments: {e:?}"
                 ))
             })?;
+            let patch = args.into_patch().map_err(|msg| {
+                FunctionCallError::RespondToModel(format!(
+                    "unsupported apply_patch arguments: {msg}"
+                ))
+            })?;
             let exec_params = ExecParams {
-                command: vec!["apply_patch".to_string(), args.input.clone()],
+                command: vec!["apply_patch".to_string(), patch],
                 cwd: turn_context.cwd.clone(),
                 timeout_ms: None,
                 env: HashMap::new(),


### PR DESCRIPTION
## Summary
- accept legacy LM Studio apply_patch payloads that omit the modern `input` field
- normalize shell-style and raw-string arguments into the patch body before invoking the tool
- update a clippy-formatted assertion that now relies on inline formatting

## Testing
- USER=codex cargo test -p codex-core

------
https://chatgpt.com/codex/tasks/task_b_68d7f85c7088832fa9eab16641f9b2d3