### PR TITLE
Ensure LM Studio requests expose apply_patch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Codex understands the following architecture aliases when `--backend lmstudio` i
 | `qwen3-moe`    | `qwen/qwen3-coder-30b`                |
 | `qwen3-moe-a3b`| `qwen/qwen3-30b-a3b-2507`             |
 
-You can also pass the exact LM Studio identifier (for example `my-org/custom-model`) if you are running a different checkpoint. Codex verifies that the requested model is available from LM Studio and surfaces clear errors when it is not.
+Aliases are case-insensitive and you can mix spaces, hyphens, or underscores (for example, `qwen3 coder 30b a3b`). You can also pass the exact LM Studio identifier (for example `my-org/custom-model`) if you are running a different checkpoint. Codex verifies that the requested model is available from LM Studio and surfaces clear errors when it is not.
 
 When you select the LM Studio backend Codex automatically enables structured JSON output so the agent can reliably capture command results. No extra flags are required.
 

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -112,6 +112,15 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             supports_reasoning_summaries: true,
             needs_special_apply_patch_instructions: true,
         )
+    } else if slug.starts_with("mistralai/devstral")
+        || slug.starts_with("qwen/qwen2")
+        || slug.starts_with("qwen/qwen3")
+    {
+        model_family!(
+            slug,
+            slug,
+            apply_patch_tool_type: Some(ApplyPatchToolType::Function),
+        )
     } else {
         None
     }
@@ -127,5 +136,29 @@ pub fn derive_default_model_family(model: &str) -> ModelFamily {
         uses_local_shell_tool: false,
         apply_patch_tool_type: None,
         base_instructions: BASE_INSTRUCTIONS.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool_apply_patch::ApplyPatchToolType;
+
+    #[test]
+    fn lmstudio_models_use_function_apply_patch_tool() {
+        for slug in [
+            "mistralai/devstral-small-2507",
+            "qwen/qwen2.5-coder-14b",
+            "qwen/qwen3-coder-30b",
+            "qwen/qwen3-30b-a3b-2507",
+        ] {
+            let family = find_family_for_model(slug)
+                .unwrap_or_else(|| panic!("expected lmstudio slug {slug:?} to map"));
+            assert_eq!(
+                family.apply_patch_tool_type,
+                Some(ApplyPatchToolType::Function),
+                "LM Studio slug {slug} should expose the function-style apply_patch tool"
+            );
+        }
     }
 }

--- a/codex-rs/exec/tests/suite/lmstudio.rs
+++ b/codex-rs/exec/tests/suite/lmstudio.rs
@@ -23,6 +23,8 @@ async fn exec_resolves_lmstudio_model_aliases() -> anyhow::Result<()> {
         ("qwen3-moe", "qwen/qwen3-coder-30b"),
         ("qwen3moe", "qwen/qwen3-coder-30b"),
         ("qwen3-moe-a3b", "qwen/qwen3-30b-a3b-2507"),
+        ("qwen3 coder 30b a3b", "qwen/qwen3-30b-a3b-2507"),
+        ("Qwen3 Coder 30B", "qwen/qwen3-coder-30b"),
     ];
 
     for (alias, expected_model) in cases {
@@ -107,5 +109,82 @@ async fn exec_resolves_lmstudio_model_aliases() -> anyhow::Result<()> {
         server.verify().await;
     }
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_enables_apply_patch_tool_for_lmstudio() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let server = responses::start_mock_server().await;
+
+    let models_payload = serde_json::json!({
+        "data": [
+            { "id": DEFAULT_LM_STUDIO_MODEL }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(models_payload))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let chat_stream = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{}}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_raw(chat_stream, "text/event-stream"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    test.cmd()
+        .env("CODEX_LM_STUDIO_BASE_URL", format!("{}/v1", server.uri()))
+        .arg("--skip-git-repo-check")
+        .arg("--backend")
+        .arg("lmstudio")
+        .arg(DEFAULT_LM_STUDIO_MODEL)
+        .assert()
+        .success();
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("failed to capture requests");
+
+    let chat_request = requests
+        .iter()
+        .find(|req| req.method == Method::POST && req.url.path() == "/v1/chat/completions")
+        .context("LM Studio chat completion request missing")?;
+
+    let payload: Value = serde_json::from_slice(&chat_request.body)
+        .context("LM Studio chat completion request should be valid JSON")?;
+    let tools = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .context("LM Studio request missing tools array")?;
+
+    assert!(
+        tools.iter().any(|tool| {
+            tool.get("type").and_then(Value::as_str) == Some("function")
+                && tool
+                    .get("function")
+                    .and_then(|fn_value| fn_value.get("name"))
+                    .and_then(Value::as_str)
+                    == Some("apply_patch")
+        }),
+        "LM Studio chat request should include the apply_patch tool: {tools:?}"
+    );
+
+    server.verify().await;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- map LM Studio model slugs to a ModelFamily that prefers the function variant of the apply_patch tool and cover it with unit tests
- confirm LM Studio tool assembly emits the apply_patch entry for both Responses and Chat Completions payloads
- extend the LM Studio exec integration test to assert the captured request advertises the apply_patch function tool

## Testing
- just fmt
- just fix -p codex-core
- just fix -p codex-exec
- cargo test -p codex-core lmstudio_models_use_function_apply_patch_tool -- --nocapture
- cargo test -p codex-core chat_completions_tools_include_apply_patch_for_lmstudio -- --nocapture
- cargo test -p codex-exec suite::lmstudio::exec_enables_apply_patch_tool_for_lmstudio -- --nocapture

------
https://chatgpt.com/codex/tasks/task_b_68d80b5c8674832f9f0d86aad1b4e918